### PR TITLE
Fix typo in method name and deprecate old usage

### DIFF
--- a/src/main/java/org/galaxio/gatling/javaapi/JdbcDsl.java
+++ b/src/main/java/org/galaxio/gatling/javaapi/JdbcDsl.java
@@ -24,8 +24,17 @@ public final class JdbcDsl {
         return new DBBaseAction(org.galaxio.gatling.jdbc.Predef.jdbc(Expressions.toStringExpression(name)));
     }
 
+    /**
+     * Deprecated typo. Use {@link #insertInto(String, String...)} instead.
+     */
+    @Deprecated
     @Nonnull
     public static BatchInsertBaseAction insetInto(@Nonnull String tableName, String... columns){
+        return insertInto(tableName, columns);
+    }
+
+    @Nonnull
+    public static BatchInsertBaseAction insertInto(@Nonnull String tableName, String... columns){
         return new BatchInsertBaseAction(org.galaxio.gatling.jdbc.Predef.insertInto(Expressions.toStringExpression(tableName),
                 new org.galaxio.gatling.jdbc.actions.actions.Columns(
                         asScala(

--- a/src/test/java/org/galaxio/performance/jdbc/test/cases/JdbcActions.java
+++ b/src/test/java/org/galaxio/performance/jdbc/test/cases/JdbcActions.java
@@ -44,12 +44,12 @@ public class JdbcActions {
 
     public static BatchActionBuilder batchTest(){
         return jdbc("Batch records").batch(
-                insetInto("TEST_TABLE", "ID", "NAME", "FLAG")
+                insertInto("TEST_TABLE", "ID", "NAME", "FLAG")
                         .values(Map.of("ID", 20, "NAME", "Test 12", "FLAG", true)),
-                insetInto("TEST_TABLE", "ID", "NAME")
+                insertInto("TEST_TABLE", "ID", "NAME")
                         .values(Map.of("ID", 40, "NAME", "Test 34")),
                 update("TEST_TABLE").set(Map.of("NAME", "Test5")).where("ID = 2"),
-                insetInto("TT", "ID", "NAME").values(Map.of("ID", UUID.randomUUID(), "NAME", "OOO342ff"))
+                insertInto("TT", "ID", "NAME").values(Map.of("ID", UUID.randomUUID(), "NAME", "OOO342ff"))
         );
     }
 

--- a/src/test/kotlin/org/galaxio/performance/jdbc/test/cases/KtJdbcActions.kt
+++ b/src/test/kotlin/org/galaxio/performance/jdbc/test/cases/KtJdbcActions.kt
@@ -40,12 +40,12 @@ object KtJdbcActions {
 
     fun batchTest(): BatchActionBuilder {
         return jdbc("Batch records").batch(
-                insetInto("TEST_TABLE", "ID", "NAME", "FLAG")
+                insertInto("TEST_TABLE", "ID", "NAME", "FLAG")
                         .values(mapOf("ID" to 20, "NAME" to "Test 12", "FLAG" to true)),
-                insetInto("TEST_TABLE", "ID", "NAME")
+                insertInto("TEST_TABLE", "ID", "NAME")
                         .values(mapOf("ID" to 40, "NAME" to "Test 34")),
                 update("TEST_TABLE").set(mapOf("NAME" to "Test5")).where("ID = 2"),
-                insetInto("TT", "ID", "NAME").values(mapOf("ID" to UUID.randomUUID(), "NAME" to "OOO342ff"))
+                insertInto("TT", "ID", "NAME").values(mapOf("ID" to UUID.randomUUID(), "NAME" to "OOO342ff"))
         )
     }
 


### PR DESCRIPTION
### What does this implement/fix?

This pull request corrects a typo in the method name `insetInto`, replacing it with the correct `insertInto`. The old method name has been marked as deprecated to maintain backward compatibility.
