### PR TITLE
Passes failed state to Gatling Scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ You may add plugin as dependency in project with your tests. Write this to your 
 ``` scala
 libraryDependencies += "org.galaxio" %% "gatling-jdbc-plugin" % <version> % Test
 ``` 
-
+Commands to build and deploy to local maven .m2 repository:
+sbt package
+sbt publishM2 
 ## Example Scenarios
 Examples [here](https://github.com/galax-io/gatling-jdbc-plugin/tree/master/src/test)

--- a/src/main/scala/org/galaxio/gatling/jdbc/actions/ActionBase.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/actions/ActionBase.scala
@@ -1,6 +1,7 @@
 package org.galaxio.gatling.jdbc.actions
 
 import io.gatling.commons.stats.Status
+import io.gatling.commons.stats.KO
 import io.gatling.core.action.Action
 import io.gatling.core.session.Session
 import io.gatling.core.structure.ScenarioContext
@@ -25,9 +26,10 @@ trait ActionBase {
   ): Unit = {
     // If the result status is KO, mark the session as failed so downstream actions see it
     // Also attach explicit attributes so Java DSL users can read it reliably
-    val sessionToUse = if (status == io.gatling.commons.stats.KO)
-      session.markAsFailed.set("jdbcFailed", true).set("successful", false).set("jdbcErrorMessage", message.getOrElse("Unknown error"))
-    else session.set("jdbcFailed", false).set("successful", true).remove("jdbcErrorMessage").remove("HelterSkelter")
+    val sessionToUse = if (status == KO)
+      session.markAsFailed.set("jdbcFailed", true).set("successful", false).set("message", message.getOrElse(""))
+    else session.set("jdbcFailed", false).set("successful", true).set("message", message.getOrElse(""))
+
     ctx.coreComponents.statsEngine.logResponse(
       session.scenario,
       session.groups,

--- a/src/main/scala/org/galaxio/gatling/jdbc/actions/ActionBase.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/actions/ActionBase.scala
@@ -23,6 +23,12 @@ trait ActionBase {
       responseCode: Option[String],
       message: Option[String],
   ): Unit = {
+    // If the result status is KO, mark the session as failed so downstream actions see it
+    // Also attach explicit attributes so Java DSL users can read it reliably
+    val sessionToUse = if (status == io.gatling.commons.stats.KO)
+      session.markAsFailed.set("jdbcFailed", true).set("successful", false)
+    else session.set("jdbcFailed", false).set("successful", true)
+
     ctx.coreComponents.statsEngine.logResponse(
       session.scenario,
       session.groups,

--- a/src/main/scala/org/galaxio/gatling/jdbc/actions/ActionBase.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/actions/ActionBase.scala
@@ -26,9 +26,8 @@ trait ActionBase {
     // If the result status is KO, mark the session as failed so downstream actions see it
     // Also attach explicit attributes so Java DSL users can read it reliably
     val sessionToUse = if (status == io.gatling.commons.stats.KO)
-      session.markAsFailed.set("jdbcFailed", true).set("successful", false)
-    else session.set("jdbcFailed", false).set("successful", true)
-
+      session.markAsFailed.set("jdbcFailed", true).set("successful", false).set("jdbcErrorMessage", message.getOrElse("Unknown error"))
+    else session.set("jdbcFailed", false).set("successful", true).remove("jdbcErrorMessage").remove("HelterSkelter")
     ctx.coreComponents.statsEngine.logResponse(
       session.scenario,
       session.groups,
@@ -39,6 +38,6 @@ trait ActionBase {
       responseCode,
       message,
     )
-    next ! session.logGroupRequestTimings(sent, received)
+    next ! sessionToUse.logGroupRequestTimings(sent, received)
   }
 }

--- a/src/test/java/org/galaxio/performance/jdbc/test/cases/JdbcActions.java
+++ b/src/test/java/org/galaxio/performance/jdbc/test/cases/JdbcActions.java
@@ -16,6 +16,12 @@ public class JdbcActions {
                                         "CREATE TABLE TT (ID UUID, NAME VARCHAR(64));");
     }
 
+    public static RawSqlActionBuilder createBadTable(){
+        return jdbc("Create table")
+                .rawSql("REATE TABLE TEST_TABLE (ID INT PRIMARY KEY, NAME VARCHAR(64), CREATED_AT DATE DEFAULT now(), flag BOOLEAN DEFAULT false);" +
+                        "CREATE TABLE TT (ID UUID, NAME VARCHAR(64));");
+    }
+
     public static RawSqlActionBuilder createprocedure(){
         return jdbc("Procedure create")
                 .rawSql(

--- a/src/test/java/org/galaxio/performance/jdbc/test/scenarios/JdbcBasicSimulation.java
+++ b/src/test/java/org/galaxio/performance/jdbc/test/scenarios/JdbcBasicSimulation.java
@@ -5,11 +5,31 @@ import org.galaxio.performance.jdbc.test.cases.JdbcActions;
 
 import static io.gatling.javaapi.core.CoreDsl.scenario;
 
+
 public class JdbcBasicSimulation {
     public static ScenarioBuilder scn = scenario("JDBC scenario")
+            .exec(JdbcActions.createBadTable())
+            .exec(session -> {
+                boolean jdbcIsFailed =  session.getBoolean("jdbcFailed");
+                boolean sessionIsFailed = session.isFailed();
+                String jdbcErrorMessage = session.getString("jdbcErrorMessage");
+                return session;
+            })
             .exec(JdbcActions.createTable())
+            .exec(session -> {
+                boolean jdbcIsFailed =  session.getBoolean("jdbcFailed");
+                boolean sessionIsFailed = session.isFailed();
+                boolean hasJdbcErrorMessage = session.contains("jdbcErrorMessage");
+                return session;
+            })
             .exec(JdbcActions.createprocedure())
             .exec(JdbcActions.insertTest())
+            .exec( session -> {
+                boolean jdbcIsFailed =  session.getBoolean("jdbcFailed");
+                boolean sessionIsFailed = session.isFailed();
+                boolean hasJdbcErrorMessage = session.contains("jdbcErrorMessage");
+                return session;
+            })
             .exec(JdbcActions.callTest())
             .exec(JdbcActions.batchTest())
             .exec(JdbcActions.selectTT())


### PR DESCRIPTION
Modifies ActionBase to pass back state that can later be picked up in the session.  This provides the ability to differentiate and log a successful query that returns zero rows and a failed query.  Without this additional state it was not possible to detect and log failed queries only that a zero row result set was provided.