### PR TITLE
fix: mark session as failed when JDBC action returns KO status

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val root = (project in file("."))
     Gatling / publishArtifact   := false,
     GatlingIt / publishArtifact := false,
     libraryDependencies ++= gatling ++ gatlingCore,
-    libraryDependencies ++= Seq(hikari, h2jdbc),
+    libraryDependencies ++= Seq(hikari, h2jdbc, scalatest),
     scalacOptions ++= Seq(
       "-encoding",
       "UTF-8",            // Option and arguments on same line

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,8 @@ object Dependencies {
     "io.gatling.highcharts" % "gatling-charts-highcharts",
   ).map(_ % gatlingVersion % "it,test")
 
-  lazy val hikari = "com.zaxxer"     % "HikariCP" % "7.0.2" exclude ("org.slf4j", "slf4j-api")
-  lazy val h2jdbc = "com.h2database" % "h2"       % "2.4.240" % Test
+  lazy val hikari    = "com.zaxxer"     % "HikariCP"  % "7.0.2" exclude ("org.slf4j", "slf4j-api")
+  lazy val h2jdbc    = "com.h2database" % "h2"        % "2.4.240" % Test
+  lazy val scalatest = "org.scalatest" %% "scalatest" % "3.2.19"  % Test
 
 }

--- a/src/main/scala/org/galaxio/gatling/jdbc/actions/ActionBase.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/actions/ActionBase.scala
@@ -1,6 +1,6 @@
 package org.galaxio.gatling.jdbc.actions
 
-import io.gatling.commons.stats.Status
+import io.gatling.commons.stats.{KO, Status}
 import io.gatling.core.action.Action
 import io.gatling.core.session.Session
 import io.gatling.core.structure.ScenarioContext
@@ -10,8 +10,8 @@ import org.galaxio.gatling.jdbc.protocol.JdbcProtocol
 trait ActionBase {
   val ctx: ScenarioContext
 
-  private val jdbcComponents         = ctx.protocolComponentsRegistry.components(JdbcProtocol.jdbcProtocolKey)
-  protected val dbClient: JDBCClient = jdbcComponents.client
+  private lazy val jdbcComponents         = ctx.protocolComponentsRegistry.components(JdbcProtocol.jdbcProtocolKey)
+  protected lazy val dbClient: JDBCClient = jdbcComponents.client
 
   protected def executeNext(
       session: Session,
@@ -33,6 +33,7 @@ trait ActionBase {
       responseCode,
       message,
     )
-    next ! session.logGroupRequestTimings(sent, received)
+    val updatedSession = if (status == KO) session.markAsFailed else session
+    next ! updatedSession.logGroupRequestTimings(sent, received)
   }
 }

--- a/src/test/scala/org/galaxio/gatling/jdbc/actions/ActionBaseSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/actions/ActionBaseSpec.scala
@@ -1,0 +1,143 @@
+package org.galaxio.gatling.jdbc.actions
+
+import io.gatling.commons.stats.{KO, OK, Status}
+import io.gatling.commons.util.Clock
+import io.gatling.core.CoreComponents
+import io.gatling.core.action.Action
+import io.gatling.core.config.GatlingConfiguration
+import io.gatling.core.protocol.ProtocolComponentsRegistry
+import io.gatling.core.session.Session
+import io.gatling.core.stats.StatsEngine
+import io.gatling.core.structure.ScenarioContext
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ActionBaseSpec extends AnyFlatSpec with Matchers {
+
+  private val testClock: Clock = new Clock {
+    override def nowMillis: Long = System.currentTimeMillis()
+  }
+
+  private val noOpStatsEngine: StatsEngine = new StatsEngine {
+    override def start(): Unit = ()
+    override def stop(controller: akka.actor.ActorRef, exception: Option[Exception]): Unit = ()
+    override def logUserStart(scenario: String): Unit = ()
+    override def logUserEnd(scenario: String): Unit = ()
+    override def logResponse(
+        scenario: String,
+        groups: List[String],
+        requestName: String,
+        startTimestamp: Long,
+        endTimestamp: Long,
+        status: Status,
+        responseCode: Option[String],
+        message: Option[String],
+    ): Unit = ()
+    override def logGroupEnd(
+        scenario: String,
+        groupBlock: io.gatling.core.session.GroupBlock,
+        exitTimestamp: Long,
+    ): Unit = ()
+    override def logRequestCrash(
+        scenario: String,
+        groups: List[String],
+        requestName: String,
+        error: String,
+    ): Unit = ()
+  }
+
+  private val coreComponents = new CoreComponents(
+    actorSystem = null,
+    eventLoopGroup = null,
+    controller = null,
+    throttler = None,
+    statsEngine = noOpStatsEngine,
+    clock = testClock,
+    exit = null,
+    configuration = GatlingConfiguration.loadForTest(),
+  )
+
+  private val scenarioCtx = new ScenarioContext(
+    coreComponents = coreComponents,
+    protocolComponentsRegistry = null.asInstanceOf[ProtocolComponentsRegistry],
+    pauseType = io.gatling.core.pause.Disabled,
+    throttled = false,
+  )
+
+  private def newSession(failed: Boolean = false): Session = {
+    val session = new Session("test-scenario", 1L, Map.empty, OK, Nil, Session.NothingOnExit, null)
+    if (failed) session.markAsFailed else session
+  }
+
+  private class CaptureAction extends Action {
+    @volatile var capturedSession: Option[Session] = None
+    override def name: String = "capture"
+    override def !(session: Session): Unit = capturedSession = Some(session)
+    override def execute(session: Session): Unit = capturedSession = Some(session)
+  }
+
+  private class TestActionBase(override val ctx: ScenarioContext) extends ActionBase {
+    def callExecuteNext(
+        session: Session,
+        sent: Long,
+        received: Long,
+        status: Status,
+        next: Action,
+        requestName: String,
+        responseCode: Option[String],
+        message: Option[String],
+    ): Unit = executeNext(session, sent, received, status, next, requestName, responseCode, message)
+  }
+
+  private val actionBase = new TestActionBase(scenarioCtx)
+
+  "executeNext with OK status" should "not mark session as failed" in {
+    val capture = new CaptureAction
+    val session = newSession()
+
+    actionBase.callExecuteNext(session, 100L, 200L, OK, capture, "test-request", None, None)
+
+    capture.capturedSession shouldBe defined
+    capture.capturedSession.get.isFailed shouldBe false
+  }
+
+  "executeNext with KO status" should "mark session as failed" in {
+    val capture = new CaptureAction
+    val session = newSession()
+
+    actionBase.callExecuteNext(session, 100L, 200L, KO, capture, "test-request", Some("ERROR"), Some("SQL error"))
+
+    capture.capturedSession shouldBe defined
+    capture.capturedSession.get.isFailed shouldBe true
+  }
+
+  "executeNext with KO status" should "preserve existing session attributes" in {
+    val capture = new CaptureAction
+    val session = newSession().set("myKey", "myValue")
+
+    actionBase.callExecuteNext(session, 100L, 200L, KO, capture, "test-request", Some("ERROR"), Some("fail"))
+
+    val result = capture.capturedSession.get
+    result.isFailed shouldBe true
+    result.contains("myKey") shouldBe true
+    result("myKey").as[String] shouldBe "myValue"
+  }
+
+  "executeNext with KO on already-failed session" should "remain failed" in {
+    val capture = new CaptureAction
+    val session = newSession(failed = true)
+
+    actionBase.callExecuteNext(session, 100L, 200L, KO, capture, "test-request", Some("ERROR"), Some("fail"))
+
+    capture.capturedSession.get.isFailed shouldBe true
+  }
+
+  "executeNext with OK on non-failed session" should "keep session successful" in {
+    val capture = new CaptureAction
+    val session = newSession()
+
+    actionBase.callExecuteNext(session, 100L, 200L, OK, capture, "test-request", None, None)
+
+    capture.capturedSession.get.isFailed shouldBe false
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/jdbc/actions/JdbcFailureSimulationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/actions/JdbcFailureSimulationSpec.scala
@@ -1,0 +1,43 @@
+package org.galaxio.gatling.jdbc.actions
+
+import io.gatling.core.Predef._
+import org.galaxio.gatling.jdbc.Predef._
+import org.galaxio.performance.jdbc.test.dataBase
+
+class JdbcFailureSimulationSpec extends Simulation {
+
+  @volatile private var sessionFailedAfterBadQuery: Option[Boolean] = None
+  @volatile private var sessionOkAfterGoodQuery: Option[Boolean] = None
+
+  private val scn = scenario("JDBC failure propagation")
+    .exec(
+      jdbc("Create test table")
+        .rawSql("CREATE TABLE IF NOT EXISTS FAIL_TEST (ID INT PRIMARY KEY, NAME VARCHAR(64))"),
+    )
+    .exec { session =>
+      sessionOkAfterGoodQuery = Some(session.isFailed)
+      session
+    }
+    .exec(
+      jdbc("Bad SQL query")
+        .rawSql("SELECT * FROM NONEXISTENT_TABLE_12345"),
+    )
+    .exec { session =>
+      sessionFailedAfterBadQuery = Some(session.isFailed)
+      session
+    }
+
+  after {
+    assert(sessionOkAfterGoodQuery.contains(false), s"Session should NOT be failed after successful query, got: $sessionOkAfterGoodQuery")
+    assert(sessionFailedAfterBadQuery.contains(true), s"Session SHOULD be failed after bad query, got: $sessionFailedAfterBadQuery")
+  }
+
+  setUp(
+    scn.inject(atOnceUsers(1)),
+  ).protocols(dataBase)
+    .maxDuration(30)
+    .assertions(
+      global.failedRequests.count.is(1L),
+      global.successfulRequests.count.gte(1L),
+    )
+}


### PR DESCRIPTION
## Summary

- **Bug:** When a JDBC action fails (DB exception, expression error, etc.), `ActionBase.executeNext` logs KO to stats engine but passes the original unmodified session to the next action. `session.isFailed` returns `false` even after a JDBC error — downstream actions cannot detect failures.
- **Fix:** Call `session.markAsFailed` in `ActionBase.executeNext` when `status == KO`. This is centralized and covers all 5 action types (Query, Insert, Raw, Call, Batch).
- **Side change:** `jdbcComponents`/`dbClient` changed from `val` to `lazy val` for testability (no behavioral change).
- **Tests:** Added ScalaTest dependency, unit tests for `ActionBase.executeNext`, and a Gatling integration test verifying session failure propagation.

Related to #12 — this is an alternative, production-ready implementation of the same fix.

## Test plan

- [x] `ActionBaseSpec` — 5 unit tests covering OK/KO status, attribute preservation, idempotency
- [x] `JdbcFailureSimulationSpec` — integration test: bad SQL → `session.isFailed == true`, good SQL → `session.isFailed == false`
- [x] Existing `DebugTest` passes without regression (13 requests, 0 KO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)