### PR TITLE
feat: document and test Gatling EL expression support in JDBC queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,46 @@ You may add plugin as dependency in project with your tests. Write this to your 
 libraryDependencies += "org.galaxio" %% "gatling-jdbc-plugin" % <version> % Test
 ``` 
 
+## Using Gatling Session Variables
+
+The plugin supports [Gatling Expression Language (EL)](https://docs.gatling.io/reference/script/core/session/el/) in SQL queries.
+Use `#{variableName}` to reference values stored in the Gatling session.
+
+### `query()` with EL
+
+Scala:
+``` scala
+exec(session => session.set("tableName", "USERS"))
+.exec(jdbc("dynamic query").query("SELECT * FROM #{tableName} WHERE id = #{id}"))
+```
+
+Java:
+``` java
+.exec(session -> session.set("tableName", "USERS"))
+.exec(jdbc("dynamic query").query("SELECT * FROM #{tableName} WHERE id = #{id}"))
+```
+
+### `queryP()` with EL
+
+`queryP` uses two different syntaxes:
+- `{param}` in SQL string — prepared statement placeholder (replaced with `?`)
+- `"#{var}"` in `.params()` — Gatling EL, resolves value from session at runtime
+
+Scala:
+``` scala
+exec(
+  jdbc("parameterized query")
+    .queryP("SELECT * FROM TEST_TABLE WHERE id = {id}")
+    .params("id" -> "#{userId}")
+)
+```
+
+Java:
+``` java
+.exec(jdbc("parameterized query")
+    .queryP("SELECT * FROM TEST_TABLE WHERE id = {id}")
+    .params(Map.of("id", "#{userId}")))
+```
+
 ## Example Scenarios
 Examples [here](https://github.com/galax-io/gatling-jdbc-plugin/tree/master/src/test)

--- a/src/main/scala/org/galaxio/gatling/jdbc/actions/DBQueryAction.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/actions/DBQueryAction.scala
@@ -71,9 +71,13 @@ case class DBQueryAction(
             Some(exception.getMessage),
           ),
       ))
-      .onFailure(m =>
+      .onFailure { m =>
+        val message =
+          if (m.contains("No attribute named"))
+            s"$m. Hint: ensure Gatling EL variable (e.g. #{varName}) is set in session before this action"
+          else m
         requestName(session).map { rn =>
-          ctx.coreComponents.statsEngine.logRequestCrash(session.scenario, session.groups, rn, m)
+          ctx.coreComponents.statsEngine.logRequestCrash(session.scenario, session.groups, rn, message)
           executeNext(
             session,
             ctx.coreComponents.clock.nowMillis,
@@ -82,10 +86,10 @@ case class DBQueryAction(
             next,
             rn,
             Some("ERROR"),
-            Some(m),
+            Some(message),
           )
-        },
-      )
+        }
+      }
 
   override def statsEngine: StatsEngine = ctx.coreComponents.statsEngine
 }

--- a/src/main/scala/org/galaxio/gatling/jdbc/actions/DBQueryAction.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/actions/DBQueryAction.scala
@@ -70,26 +70,25 @@ case class DBQueryAction(
             Some("ERROR"),
             Some(exception.getMessage),
           ),
-      ))
-      .onFailure { m =>
-        val message =
-          if (m.contains("No attribute named"))
-            s"$m. Hint: ensure Gatling EL variable (e.g. #{varName}) is set in session before this action"
-          else m
-        requestName(session).map { rn =>
-          ctx.coreComponents.statsEngine.logRequestCrash(session.scenario, session.groups, rn, message)
-          executeNext(
-            session,
-            ctx.coreComponents.clock.nowMillis,
-            ctx.coreComponents.clock.nowMillis,
-            KO,
-            next,
-            rn,
-            Some("ERROR"),
-            Some(message),
-          )
-        }
+      )).onFailure { m =>
+      val message =
+        if (m.contains("No attribute named"))
+          s"$m. Hint: ensure Gatling EL variable (e.g. #{varName}) is set in session before this action"
+        else m
+      requestName(session).map { rn =>
+        ctx.coreComponents.statsEngine.logRequestCrash(session.scenario, session.groups, rn, message)
+        executeNext(
+          session,
+          ctx.coreComponents.clock.nowMillis,
+          ctx.coreComponents.clock.nowMillis,
+          KO,
+          next,
+          rn,
+          Some("ERROR"),
+          Some(message),
+        )
       }
+    }
 
   override def statsEngine: StatsEngine = ctx.coreComponents.statsEngine
 }

--- a/src/main/scala/org/galaxio/gatling/jdbc/actions/DBRawQueryAction.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/actions/DBRawQueryAction.scala
@@ -35,9 +35,13 @@ case class DBRawQueryAction(requestName: Expression[String], query: Expression[S
             Some(exception.getMessage),
           ),
       ))
-      .onFailure(m =>
+      .onFailure { m =>
+        val message =
+          if (m.contains("No attribute named"))
+            s"$m. Hint: ensure Gatling EL variable (e.g. #{varName}) is set in session before this action"
+          else m
         requestName(session).map { rn =>
-          ctx.coreComponents.statsEngine.logRequestCrash(session.scenario, session.groups, rn, m)
+          ctx.coreComponents.statsEngine.logRequestCrash(session.scenario, session.groups, rn, message)
           executeNext(
             session,
             ctx.coreComponents.clock.nowMillis,
@@ -46,10 +50,10 @@ case class DBRawQueryAction(requestName: Expression[String], query: Expression[S
             next,
             rn,
             Some("ERROR"),
-            Some(m),
+            Some(message),
           )
-        },
-      )
+        }
+      }
 
   override def statsEngine: StatsEngine = ctx.coreComponents.statsEngine
 }

--- a/src/main/scala/org/galaxio/gatling/jdbc/actions/DBRawQueryAction.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/actions/DBRawQueryAction.scala
@@ -34,26 +34,25 @@ case class DBRawQueryAction(requestName: Expression[String], query: Expression[S
             Some("ERROR"),
             Some(exception.getMessage),
           ),
-      ))
-      .onFailure { m =>
-        val message =
-          if (m.contains("No attribute named"))
-            s"$m. Hint: ensure Gatling EL variable (e.g. #{varName}) is set in session before this action"
-          else m
-        requestName(session).map { rn =>
-          ctx.coreComponents.statsEngine.logRequestCrash(session.scenario, session.groups, rn, message)
-          executeNext(
-            session,
-            ctx.coreComponents.clock.nowMillis,
-            ctx.coreComponents.clock.nowMillis,
-            KO,
-            next,
-            rn,
-            Some("ERROR"),
-            Some(message),
-          )
-        }
+      )).onFailure { m =>
+      val message =
+        if (m.contains("No attribute named"))
+          s"$m. Hint: ensure Gatling EL variable (e.g. #{varName}) is set in session before this action"
+        else m
+      requestName(session).map { rn =>
+        ctx.coreComponents.statsEngine.logRequestCrash(session.scenario, session.groups, rn, message)
+        executeNext(
+          session,
+          ctx.coreComponents.clock.nowMillis,
+          ctx.coreComponents.clock.nowMillis,
+          KO,
+          next,
+          rn,
+          Some("ERROR"),
+          Some(message),
+        )
       }
+    }
 
   override def statsEngine: StatsEngine = ctx.coreComponents.statsEngine
 }

--- a/src/test/java/org/galaxio/performance/jdbc/test/cases/JdbcActions.java
+++ b/src/test/java/org/galaxio/performance/jdbc/test/cases/JdbcActions.java
@@ -73,6 +73,13 @@ public class JdbcActions {
                 .check(allResults().saveAs("RR"));
     }
 
+    public static QueryActionBuilder selectWithEL(){
+        return jdbc("SELECT WITH EL")
+                .query("SELECT * FROM TEST_TABLE WHERE ID = #{elId}")
+                .check(simpleCheck(simpleCheckType.NonEmpty),
+                        allResults().saveAs("elResult"));
+    }
+
     public static QueryActionBuilder checkTestTableAfterBatch(){
         return jdbc("Check TEST_TABLE")
                 .query("SELECT * FROM TEST_TABLE WHERE EXISTS(SELECT NAME FROM TEST_TABLE WHERE ID = 2 AND NAME = 'Test5')" +

--- a/src/test/java/org/galaxio/performance/jdbc/test/scenarios/JdbcBasicSimulation.java
+++ b/src/test/java/org/galaxio/performance/jdbc/test/scenarios/JdbcBasicSimulation.java
@@ -14,6 +14,8 @@ public class JdbcBasicSimulation {
             .exec(JdbcActions.batchTest())
             .exec(JdbcActions.selectTT())
             .exec(JdbcActions.selectTest())
+            .exec(session -> session.set("elId", 20))
+            .exec(JdbcActions.selectWithEL())
             .exec(JdbcActions.selectAfterBatch())
             .exec(JdbcActions.checkTestTableAfterBatch())
             ;

--- a/src/test/scala/org/galaxio/gatling/jdbc/actions/ActionBaseSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/actions/ActionBaseSpec.scala
@@ -19,10 +19,10 @@ class ActionBaseSpec extends AnyFlatSpec with Matchers {
   }
 
   private val noOpStatsEngine: StatsEngine = new StatsEngine {
-    override def start(): Unit = ()
+    override def start(): Unit                                                             = ()
     override def stop(controller: akka.actor.ActorRef, exception: Option[Exception]): Unit = ()
-    override def logUserStart(scenario: String): Unit = ()
-    override def logUserEnd(scenario: String): Unit = ()
+    override def logUserStart(scenario: String): Unit                                      = ()
+    override def logUserEnd(scenario: String): Unit                                        = ()
     override def logResponse(
         scenario: String,
         groups: List[String],
@@ -32,18 +32,18 @@ class ActionBaseSpec extends AnyFlatSpec with Matchers {
         status: Status,
         responseCode: Option[String],
         message: Option[String],
-    ): Unit = ()
+    ): Unit                                                                                = ()
     override def logGroupEnd(
         scenario: String,
         groupBlock: io.gatling.core.session.GroupBlock,
         exitTimestamp: Long,
-    ): Unit = ()
+    ): Unit                                                                                = ()
     override def logRequestCrash(
         scenario: String,
         groups: List[String],
         requestName: String,
         error: String,
-    ): Unit = ()
+    ): Unit                                                                                = ()
   }
 
   private val coreComponents = new CoreComponents(
@@ -71,9 +71,9 @@ class ActionBaseSpec extends AnyFlatSpec with Matchers {
 
   private class CaptureAction extends Action {
     @volatile var capturedSession: Option[Session] = None
-    override def name: String = "capture"
-    override def !(session: Session): Unit = capturedSession = Some(session)
-    override def execute(session: Session): Unit = capturedSession = Some(session)
+    override def name: String                      = "capture"
+    override def !(session: Session): Unit         = capturedSession = Some(session)
+    override def execute(session: Session): Unit   = capturedSession = Some(session)
   }
 
   private class TestActionBase(override val ctx: ScenarioContext) extends ActionBase {

--- a/src/test/scala/org/galaxio/gatling/jdbc/actions/JdbcFailureSimulationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/actions/JdbcFailureSimulationSpec.scala
@@ -7,7 +7,7 @@ import org.galaxio.performance.jdbc.test.dataBase
 class JdbcFailureSimulationSpec extends Simulation {
 
   @volatile private var sessionFailedAfterBadQuery: Option[Boolean] = None
-  @volatile private var sessionOkAfterGoodQuery: Option[Boolean] = None
+  @volatile private var sessionOkAfterGoodQuery: Option[Boolean]    = None
 
   private val scn = scenario("JDBC failure propagation")
     .exec(
@@ -28,8 +28,14 @@ class JdbcFailureSimulationSpec extends Simulation {
     }
 
   after {
-    assert(sessionOkAfterGoodQuery.contains(false), s"Session should NOT be failed after successful query, got: $sessionOkAfterGoodQuery")
-    assert(sessionFailedAfterBadQuery.contains(true), s"Session SHOULD be failed after bad query, got: $sessionFailedAfterBadQuery")
+    assert(
+      sessionOkAfterGoodQuery.contains(false),
+      s"Session should NOT be failed after successful query, got: $sessionOkAfterGoodQuery",
+    )
+    assert(
+      sessionFailedAfterBadQuery.contains(true),
+      s"Session SHOULD be failed after bad query, got: $sessionFailedAfterBadQuery",
+    )
   }
 
   setUp(

--- a/src/test/scala/org/galaxio/performance/jdbc/test/cases/Actions.scala
+++ b/src/test/scala/org/galaxio/performance/jdbc/test/cases/Actions.scala
@@ -83,4 +83,9 @@ object Actions {
       .check(
         simpleCheck(x => x.length == 1),
       )
+
+  def selectWithEL: QueryActionBuilder =
+    jdbc("SELECT WITH EL")
+      .query("SELECT * FROM TEST_TABLE WHERE ID = #{elId}")
+      .check(simpleCheck(_.nonEmpty), allResults.saveAs("elResult"))
 }

--- a/src/test/scala/org/galaxio/performance/jdbc/test/scenarios/BasicSimulation.scala
+++ b/src/test/scala/org/galaxio/performance/jdbc/test/scenarios/BasicSimulation.scala
@@ -36,5 +36,7 @@ class BasicSimulation {
     }
     .exec(Actions.checkBatchTestTable)
     .exec(Actions.checkBatchTT)
+    .exec(session => session.set("elId", 1))
+    .exec(Actions.selectWithEL)
 
 }


### PR DESCRIPTION
## Summary

- Added README section "Using Gatling Session Variables" explaining how to use `#{var}` in `query()` and `queryP()` — with Scala and Java examples
- Clarified the difference between `{param}` (prepared statement placeholder) and `#{var}` (Gatling EL session resolution) in `queryP`
- Added integration tests (`selectWithEL`) for both Scala and Java APIs proving EL resolution works
- Improved error messages in `DBQueryAction` and `DBRawQueryAction` — when EL variable is missing from session, error now hints to check session variable setup

Resolves [Tinkoff#77](https://github.com/Tinkoff/gatling-jdbc-plugin/issues/77) / [galax-io#1](https://github.com/galax-io/gatling-jdbc-plugin/issues/1)

## Context

Users expected `jdbc("test").query("select * from #{tbl}")` to work but didn't know it already does. Some tried wrapping JDBC calls in `session -> { ... }` lambdas (which returns `ActionBuilder`, not `Session`). The EL support was always there via `Expression[String]` in Scala DSL and `Expressions.toStringExpression()` in Java API — it just needed documentation and tests.

## Test plan

- [x] `sbt compile` — clean
- [x] `sbt test` — all unit tests pass
- [x] Scala Gatling simulation (`DebugTest`) — 14/14 OK, including `SELECT WITH EL`
- [x] Java Gatling simulation (`JdbcDebugTest`) — `SELECT WITH EL` OK (1 pre-existing KO on `CALL PROCEDURE TEST` unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)