### PR TITLE
add jdbc result extractors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Repository Instructions
+
+- Before any `git commit` or `git push`, always run `sbt scalafmtAll scalafmtSbt`.
+- If formatting changes files, review them and include the relevant formatted changes before publishing.

--- a/README.md
+++ b/README.md
@@ -57,3 +57,67 @@ Java:
 
 ## Example Scenarios
 Examples [here](https://github.com/galax-io/gatling-jdbc-plugin/tree/master/src/test)
+
+## Inspecting Query Results
+
+JDBC query checks operate on a result set represented as a list of rows, where each row is a map keyed by the SQL column label:
+
+- Scala session type saved by `allResults.saveAs("rows")`: `List[Map[String, Any]]`
+- Java/Kotlin session type saved by `allResults().saveAs("rows")`: Scala immutable collections exposed through Gatling's Java API
+
+Column aliases are supported. For example, `SELECT user_id AS id` makes the value available under `id`.
+
+### Available Result Checks
+
+- `allResults` / `allResults()` - extract the full result set
+- `row(index)` - extract a single row by zero-based index
+- `column(name)` - extract all values from a column
+- `cell(name, rowIndex)` - extract a single value from a column at the given zero-based row index
+
+When a row index or column name is invalid, the check fails with a descriptive error message.
+
+### Scala
+
+```scala
+import io.gatling.core.Predef._
+import org.galaxio.gatling.jdbc.Predef._
+
+jdbc("select users")
+  .query("SELECT ID AS USER_ID, NAME FROM USERS ORDER BY ID")
+  .check(
+    cell("NAME", 0).is("Alice"),
+    row(0).saveAs("firstRow"),
+    column("USER_ID").saveAs("userIds"),
+    allResults.saveAs("rows"),
+  )
+```
+
+### Java
+
+```java
+import static org.galaxio.gatling.javaapi.JdbcDsl.*;
+
+jdbc("select users")
+    .query("SELECT ID AS USER_ID, NAME FROM USERS ORDER BY ID")
+    .check(
+        cell("NAME", 0).saveAs("firstName"),
+        row(0).saveAs("firstRow"),
+        column("USER_ID").saveAs("userIds"),
+        allResults().saveAs("rows")
+    );
+```
+
+### Kotlin
+
+```kotlin
+import org.galaxio.gatling.javaapi.JdbcDsl.*
+
+jdbc("select users")
+    .query("SELECT ID AS USER_ID, NAME FROM USERS ORDER BY ID")
+    .check(
+        cell("NAME", 0).saveAs("firstName"),
+        row(0).saveAs("firstRow"),
+        column("USER_ID").saveAs("userIds"),
+        allResults().saveAs("rows")
+    )
+```

--- a/src/main/java/org/galaxio/gatling/javaapi/JdbcDsl.java
+++ b/src/main/java/org/galaxio/gatling/javaapi/JdbcDsl.java
@@ -10,6 +10,7 @@ import org.galaxio.gatling.jdbc.check.JdbcCheckSupport;
 
 import javax.annotation.Nonnull;
 import java.util.Arrays;
+import java.util.Objects;
 
 import static scala.jdk.javaapi.CollectionConverters.asScala;
 
@@ -57,6 +58,21 @@ public final class JdbcDsl {
     @Nonnull
     public static io.gatling.core.check.CheckBuilder.Final<JdbcCheckSupport.JdbcAllRecordCheckType,scala.collection.immutable.List<scala.collection.immutable.Map<java.lang.String,java.lang.Object>>> allResults(){
         return org.galaxio.gatling.jdbc.internal.JdbcCheck.results();
+    }
+
+    @Nonnull
+    public static io.gatling.core.check.CheckBuilder.Final<JdbcCheckSupport.JdbcAllRecordCheckType,scala.collection.immutable.Map<java.lang.String,java.lang.Object>> row(int rowIndex){
+        return org.galaxio.gatling.jdbc.internal.JdbcCheck.javaRow(rowIndex);
+    }
+
+    @Nonnull
+    public static io.gatling.core.check.CheckBuilder.Final<JdbcCheckSupport.JdbcAllRecordCheckType,scala.collection.immutable.List<java.lang.Object>> column(@Nonnull String columnName){
+        return org.galaxio.gatling.jdbc.internal.JdbcCheck.javaColumn(Objects.requireNonNull(columnName, "columnName cannot be null"));
+    }
+
+    @Nonnull
+    public static io.gatling.core.check.CheckBuilder.Final<JdbcCheckSupport.JdbcAllRecordCheckType,java.lang.Object> cell(@Nonnull String columnName, int rowIndex){
+        return org.galaxio.gatling.jdbc.internal.JdbcCheck.javaCell(Objects.requireNonNull(columnName, "columnName cannot be null"), rowIndex);
     }
 
 }

--- a/src/main/scala/org/galaxio/gatling/jdbc/check/JdbcCheckSupport.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/check/JdbcCheckSupport.scala
@@ -12,8 +12,36 @@ trait JdbcCheckSupport {
   trait JdbcAllRecordCheckType
 
   type AllRecordResult = List[Map[String, Any]]
+  type JdbcRow = Map[String, Any]
+  type JdbcColumn = List[Any]
 
   val AllRecordPreparer: Preparer[AllRecordResult, AllRecordResult] = something => something.success
+
+  private def availableColumns(response: AllRecordResult): String =
+    response.headOption
+      .map(_.keys.toList.sorted.mkString(", "))
+      .getOrElse("<none>")
+
+  private def extractRow(response: AllRecordResult, rowIndex: Int): Validation[JdbcRow] =
+    response.lift(rowIndex) match {
+      case Some(row) => row.success
+      case None      => s"Row index $rowIndex is out of bounds for ${response.size} row(s)".failure
+    }
+
+  private def extractColumnValue(row: JdbcRow, columnName: String, response: AllRecordResult): Validation[Any] =
+    row.get(columnName) match {
+      case Some(value) => value.success
+      case None        =>
+        s"Column '$columnName' was not found. Available columns: ${availableColumns(response)}".failure
+    }
+
+  private def extractColumn(response: AllRecordResult, columnName: String): Validation[JdbcColumn] =
+    response.foldLeft(List.empty[Any].success) { (acc, row) =>
+      for {
+        values <- acc
+        value  <- extractColumnValue(row, columnName, response)
+      } yield values :+ value
+    }
 
   def simpleCheck(f: AllRecordResult => Boolean): JdbcCheck =
     Check.Simple(
@@ -59,6 +87,48 @@ trait JdbcCheckSupport {
   )
 
   val allResults: CheckBuilder.Find.Default[JdbcAllRecordCheckType, AllRecordResult, AllRecordResult] = AllRecordResults
+
+  def row(rowIndex: Int): CheckBuilder.Find.Default[JdbcAllRecordCheckType, AllRecordResult, JdbcRow] =
+    new CheckBuilder.Find.Default(
+      new Extractor[AllRecordResult, JdbcRow] {
+        override def name: String = s"row($rowIndex)"
+
+        override def apply(prepared: AllRecordResult): Validation[Option[JdbcRow]] =
+          extractRow(prepared, rowIndex).map(Some(_))
+
+        override def arity: String = "find"
+      }.expressionSuccess,
+      displayActualValue = true,
+    )
+
+  def column(columnName: String): CheckBuilder.Find.Default[JdbcAllRecordCheckType, AllRecordResult, JdbcColumn] =
+    new CheckBuilder.Find.Default[JdbcAllRecordCheckType, AllRecordResult, JdbcColumn](
+      new Extractor[AllRecordResult, JdbcColumn] {
+        override def name: String = s"column($columnName)"
+
+        override def apply(prepared: AllRecordResult): Validation[Option[JdbcColumn]] =
+          extractColumn(prepared, columnName).map(Some(_))
+
+        override def arity: String = "find"
+      }.expressionSuccess,
+      displayActualValue = true,
+    )
+
+  def cell(columnName: String, rowIndex: Int): CheckBuilder.Find.Default[JdbcAllRecordCheckType, AllRecordResult, Any] =
+    new CheckBuilder.Find.Default(
+      new Extractor[AllRecordResult, Any] {
+        override def name: String = s"cell($columnName, $rowIndex)"
+
+        override def apply(prepared: AllRecordResult): Validation[Option[Any]] =
+          for {
+            row   <- extractRow(prepared, rowIndex)
+            value <- extractColumnValue(row, columnName, prepared)
+          } yield Some(value)
+
+        override def arity: String = "find"
+      }.expressionSuccess,
+      displayActualValue = true,
+    )
 
   val allRecordsCheck: JdbcAllRecordsCheck.type = JdbcAllRecordsCheck
 

--- a/src/main/scala/org/galaxio/gatling/jdbc/check/JdbcCheckSupport.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/check/JdbcCheckSupport.scala
@@ -12,8 +12,8 @@ trait JdbcCheckSupport {
   trait JdbcAllRecordCheckType
 
   type AllRecordResult = List[Map[String, Any]]
-  type JdbcRow = Map[String, Any]
-  type JdbcColumn = List[Any]
+  type JdbcRow         = Map[String, Any]
+  type JdbcColumn      = List[Any]
 
   val AllRecordPreparer: Preparer[AllRecordResult, AllRecordResult] = something => something.success
 

--- a/src/main/scala/org/galaxio/gatling/jdbc/db/package.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/db/package.scala
@@ -67,7 +67,7 @@ package object db {
     val md      = resultSet.getMetaData
     val columns = md.getColumnCount
     (1 to columns).foldLeft(Map.empty[String, Any]) { (m, i) =>
-      m + (md.getColumnName(i) -> resultSet.getObject(i))
+      m + (md.getColumnLabel(i) -> resultSet.getObject(i))
     }
   }
 

--- a/src/main/scala/org/galaxio/gatling/jdbc/internal/JdbcCheck.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/internal/JdbcCheck.scala
@@ -26,12 +26,25 @@ object JdbcCheck extends JdbcCheckSupport {
   def results(): Final[JdbcAllRecordCheckType, AllRecordResult] =
     find2Final(allResults)
 
+  def javaRow(rowIndex: Int): Final[JdbcAllRecordCheckType, Map[String, Any]] =
+    find2Final(row(rowIndex).asInstanceOf[CheckBuilder.Find[JdbcAllRecordCheckType, Map[String, Any], AllRecordResult]])
+
+  def javaColumn(columnName: String): Final[JdbcAllRecordCheckType, List[Any]] =
+    find2Final(column(columnName).asInstanceOf[CheckBuilder.Find[JdbcAllRecordCheckType, List[Any], AllRecordResult]])
+
+  def javaCell(columnName: String, rowIndex: Int): Final[JdbcAllRecordCheckType, Any] =
+    find2Final(cell(columnName, rowIndex).asInstanceOf[CheckBuilder.Find[JdbcAllRecordCheckType, Any, AllRecordResult]])
+
   private def toScalaCheck(javaCheck: Object): JdbcCheck = {
     javaCheck match {
       case simpleCheck: Simple[_]                            => simpleCheck.asInstanceOf[Simple[AllRecordResult]]
       case defaultCheck: CheckBuilder.Final.Default[_, _, _] =>
         checkBuilder2JdbcCheck(
-          defaultCheck.asInstanceOf[Default[JdbcAllRecordCheckType, AllRecordResult, AllRecordResult]],
+          defaultCheck.asInstanceOf[Default[JdbcAllRecordCheckType, AllRecordResult, Any]],
+        )
+      case findCheck: CheckBuilder.Find.Default[_, _, _]     =>
+        findCheckBuilder2JdbcCheck(
+          findCheck.asInstanceOf[CheckBuilder.Find.Default[JdbcAllRecordCheckType, AllRecordResult, Any]],
         )
       case unknown                                           => throw new IllegalArgumentException(s"JDBC DSL doesn't support $unknown")
     }

--- a/src/test/java/org/galaxio/performance/jdbc/test/cases/JdbcActions.java
+++ b/src/test/java/org/galaxio/performance/jdbc/test/cases/JdbcActions.java
@@ -64,6 +64,9 @@ public class JdbcActions {
                 .queryP("SELECT * FROM TEST_TABLE WHERE ID = {id}")
                 .params(Map.of("id", 20))
                 .check(simpleCheck(simpleCheckType.NonEmpty),
+                        cell("NAME", 0).saveAs("FIRST_TEST_NAME"),
+                        row(0).saveAs("FIRST_TEST_ROW"),
+                        column("NAME").saveAs("TEST_NAMES"),
                         allResults().saveAs("R"));
     }
 

--- a/src/test/kotlin/org/galaxio/performance/jdbc/test/cases/KtJdbcActions.kt
+++ b/src/test/kotlin/org/galaxio/performance/jdbc/test/cases/KtJdbcActions.kt
@@ -60,6 +60,9 @@ object KtJdbcActions {
                 .queryP("SELECT * FROM TEST_TABLE WHERE ID = {id}")
                 .params(mapOf("id" to 20))
                 .check(simpleCheck(simpleCheckType.NonEmpty),
+                        cell("NAME", 0).saveAs("FIRST_TEST_NAME"),
+                        row(0).saveAs("FIRST_TEST_ROW"),
+                        column("NAME").saveAs("TEST_NAMES"),
                         allResults().saveAs("R"))
     }
 

--- a/src/test/scala/org/galaxio/gatling/jdbc/actions/JdbcQueryChecksSimulationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/actions/JdbcQueryChecksSimulationSpec.scala
@@ -1,0 +1,66 @@
+package org.galaxio.gatling.jdbc.actions
+
+import io.gatling.core.Predef._
+import org.galaxio.gatling.jdbc.Predef._
+import org.galaxio.performance.jdbc.test.dataBase
+
+class JdbcQueryChecksSimulationSpec extends Simulation {
+
+  @volatile private var extractedFirstName: Option[String]              = None
+  @volatile private var extractedIds: Option[List[Any]]                 = None
+  @volatile private var extractedAliasedRow: Option[Map[String, Any]]   = None
+  @volatile private var extractedAliasedCell: Option[String]            = None
+
+  private val scn = scenario("JDBC query checks")
+    .exec(
+      jdbc("Create people table").rawSql(
+        """CREATE TABLE PEOPLE (
+          |  ID INT PRIMARY KEY,
+          |  NAME VARCHAR(64)
+          |);""".stripMargin,
+      ),
+    )
+    .exec(
+      jdbc("Seed people table").rawSql(
+        """INSERT INTO PEOPLE (ID, NAME) VALUES
+          |(1, 'Alice'),
+          |(2, 'Bob');""".stripMargin,
+      ),
+    )
+    .exec(
+      jdbc("Select aliased people")
+        .query("SELECT ID AS PERSON_ID, NAME AS DISPLAY_NAME FROM PEOPLE ORDER BY ID")
+        .check(
+          cell("DISPLAY_NAME", 0).find.is("Alice"),
+          column("PERSON_ID").find.saveAs("personIds"),
+          row(1).find.saveAs("secondRow"),
+          cell("DISPLAY_NAME", 1).find.saveAs("secondName"),
+        ),
+    )
+    .exec { session =>
+      extractedFirstName = Some(session("secondName").as[String])
+      extractedIds = Some(session("personIds").as[List[Any]])
+      extractedAliasedRow = Some(session("secondRow").as[Map[String, Any]])
+      extractedAliasedCell = Some(session("secondName").as[String])
+      session
+    }
+
+  after {
+    assert(extractedFirstName.contains("Bob"), s"Expected Bob, got $extractedFirstName")
+    assert(extractedAliasedCell.contains("Bob"), s"Expected aliased cell Bob, got $extractedAliasedCell")
+    assert(extractedIds.contains(List(1, 2)), s"Expected aliased IDs List(1, 2), got $extractedIds")
+    assert(
+      extractedAliasedRow.contains(Map("PERSON_ID" -> 2, "DISPLAY_NAME" -> "Bob")),
+      s"Expected aliased row with PERSON_ID and DISPLAY_NAME, got $extractedAliasedRow",
+    )
+  }
+
+  setUp(
+    scn.inject(atOnceUsers(1)),
+  ).protocols(dataBase)
+    .maxDuration(30)
+    .assertions(
+      global.failedRequests.count.is(0L),
+      global.successfulRequests.count.is(3L),
+    )
+}

--- a/src/test/scala/org/galaxio/gatling/jdbc/actions/JdbcQueryChecksSimulationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/actions/JdbcQueryChecksSimulationSpec.scala
@@ -6,10 +6,10 @@ import org.galaxio.performance.jdbc.test.dataBase
 
 class JdbcQueryChecksSimulationSpec extends Simulation {
 
-  @volatile private var extractedFirstName: Option[String]              = None
-  @volatile private var extractedIds: Option[List[Any]]                 = None
-  @volatile private var extractedAliasedRow: Option[Map[String, Any]]   = None
-  @volatile private var extractedAliasedCell: Option[String]            = None
+  @volatile private var extractedFirstName: Option[String]            = None
+  @volatile private var extractedIds: Option[List[Any]]               = None
+  @volatile private var extractedAliasedRow: Option[Map[String, Any]] = None
+  @volatile private var extractedAliasedCell: Option[String]          = None
 
   private val scn = scenario("JDBC query checks")
     .exec(

--- a/src/test/scala/org/galaxio/gatling/jdbc/check/JdbcCheckSupportSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/check/JdbcCheckSupportSpec.scala
@@ -1,0 +1,71 @@
+package org.galaxio.gatling.jdbc.check
+
+import io.gatling.commons.stats.OK
+import io.gatling.commons.validation.Failure
+import io.gatling.core.Predef._
+import io.gatling.core.check.Check
+import io.gatling.core.session.Session
+import org.galaxio.gatling.jdbc.JdbcCheck
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.{HashMap => JHashMap}
+
+class JdbcCheckSupportSpec extends AnyFlatSpec with Matchers with JdbcCheckSupport {
+
+  private def session(): Session =
+    new Session("jdbc-check-support-spec", 1L, Map.empty, OK, Nil, Session.NothingOnExit, null)
+
+  private def runChecks(response: AllRecordResult, checks: JdbcCheck*): (Session, Option[Failure]) = {
+    val (updatedSession, error) = Check.check(response, session(), checks.toList, new JHashMap[Any, Any]())
+    (updatedSession.asInstanceOf[Session], error)
+  }
+
+  private val rows = List(
+    Map("ID" -> 1, "NAME" -> "Alice"),
+    Map("ID" -> 2, "NAME" -> "Bob"),
+  )
+
+  "row" should "save a row by index" in {
+    val (updatedSession, error) = runChecks(rows, row(0).saveAs("firstRow"))
+
+    error shouldBe None
+    updatedSession.attributes("firstRow") shouldBe Map("ID" -> 1, "NAME" -> "Alice")
+  }
+
+  "column" should "save all values for the requested column" in {
+    val (updatedSession, error) = runChecks(rows, column("NAME").saveAs("names"))
+
+    error shouldBe None
+    updatedSession.attributes("names") shouldBe List("Alice", "Bob")
+  }
+
+  "cell" should "support value assertions" in {
+    val (_, error) = runChecks(rows, cell("NAME", 1).is("Bob"))
+
+    error shouldBe None
+  }
+
+  it should "fail with a useful message when the column is missing" in {
+    val (_, error) = runChecks(rows, cell("AGE", 0).exists)
+
+    error match {
+      case Some(Failure(message)) =>
+        message should include("Column 'AGE' was not found")
+        message should include("ID")
+        message should include("NAME")
+      case other                  => fail(s"Expected a failed validation, got $other")
+    }
+  }
+
+  "row" should "fail with a useful message when the index is out of bounds" in {
+    val (_, error) = runChecks(rows, row(3).exists)
+
+    error match {
+      case Some(Failure(message)) =>
+        message should include("Row index 3 is out of bounds")
+        message should include("2 row(s)")
+      case other                  => fail(s"Expected a failed validation, got $other")
+    }
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/jdbc/db/ResultSetOpsSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/db/ResultSetOpsSpec.scala
@@ -1,0 +1,41 @@
+package org.galaxio.gatling.jdbc.db
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.sql.DriverManager
+
+class ResultSetOpsSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+
+  private val connection = DriverManager.getConnection("jdbc:h2:mem:result-set-ops;DB_CLOSE_DELAY=-1", "sa", "")
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    val statement = connection.createStatement()
+    try {
+      statement.execute("CREATE TABLE PEOPLE (ID INT PRIMARY KEY, NAME VARCHAR(64))")
+      statement.execute("INSERT INTO PEOPLE (ID, NAME) VALUES (1, 'Alice')")
+    } finally {
+      statement.close()
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    connection.close()
+    super.afterAll()
+  }
+
+  "ResultSetOps" should "use column labels so aliases are available to checks" in {
+    val statement = connection.createStatement()
+    try {
+      val rs = statement.executeQuery("SELECT ID AS PERSON_ID, NAME AS DISPLAY_NAME FROM PEOPLE")
+      val rows = rs.iterator.toList
+
+      rows should have size 1
+      rows.head shouldBe Map("PERSON_ID" -> 1, "DISPLAY_NAME" -> "Alice")
+    } finally {
+      statement.close()
+    }
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/jdbc/db/ResultSetOpsSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/db/ResultSetOpsSpec.scala
@@ -29,7 +29,7 @@ class ResultSetOpsSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll 
   "ResultSetOps" should "use column labels so aliases are available to checks" in {
     val statement = connection.createStatement()
     try {
-      val rs = statement.executeQuery("SELECT ID AS PERSON_ID, NAME AS DISPLAY_NAME FROM PEOPLE")
+      val rs   = statement.executeQuery("SELECT ID AS PERSON_ID, NAME AS DISPLAY_NAME FROM PEOPLE")
       val rows = rs.iterator.toList
 
       rows should have size 1


### PR DESCRIPTION
## What changed
- added JDBC result extractors for `row(index)`, `column(name)`, and `cell(name, rowIndex)` in the Scala DSL
- added Java API wrappers for the new extractors and documented the new result inspection flow in the README
- switched JDBC result mapping to column labels so SQL aliases work consistently in checks
- added unit coverage for extractor behavior and alias handling plus a Gatling integration simulation for end-to-end validation

## Why it changed
Issue requests asked for a more ergonomic way to inspect query results than `simpleCheck` and to clarify what `saveAs()` stores. This change adds first-class extraction APIs and better failure messages for invalid row and column lookups.

## Impact
Users can now target a single row, a column, or a specific cell directly from JDBC checks instead of saving the whole result set and unpacking it manually. SQL aliases are also now honored during extraction.

## Root cause
The plugin previously exposed only `simpleCheck` and `allResults`, and result rows were keyed by JDBC column name instead of column label, which made aliased queries awkward to validate.

## Validation
- `sbt test`
- `sbt 'Gatling / testOnly org.galaxio.gatling.jdbc.actions.JdbcQueryChecksSimulationSpec'`
