### PR TITLE
fix native thread explosion in jdbc blocking pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ var dataBase = DB()
     .protocolBuilder();
 ```
 
+### Kotlin
+
+```kotlin
+import org.galaxio.gatling.javaapi.JdbcDsl.DB
+import org.galaxio.gatling.javaapi.protocol.JdbcProtocolBuilder
+
+val dataBase: JdbcProtocolBuilder = DB()
+    .url("jdbc:postgresql://localhost:5432/test")
+    .username("user")
+    .password("pass")
+    .maximumPoolSize(32)
+    .blockingPoolSize(32)
+    .protocolBuilder()
+```
+
 ## Example Scenarios
 Examples [here](https://github.com/galax-io/gatling-jdbc-plugin/tree/master/src/test)
 
@@ -137,4 +152,19 @@ jdbc("select users")
         column("USER_ID").saveAs("userIds"),
         allResults().saveAs("rows")
     );
+```
+
+### Kotlin
+
+```kotlin
+import org.galaxio.gatling.javaapi.JdbcDsl.*
+
+jdbc("select users")
+    .query("SELECT ID AS USER_ID, NAME FROM USERS ORDER BY ID")
+    .check(
+        cell("NAME", 0).saveAs("firstName"),
+        row(0).saveAs("firstRow"),
+        column("USER_ID").saveAs("userIds"),
+        allResults().saveAs("rows")
+    )
 ```

--- a/README.md
+++ b/README.md
@@ -55,6 +55,38 @@ Java:
     .params(Map.of("id", "#{userId}")))
 ```
 
+## Blocking Executor
+
+JDBC calls are blocking, so the plugin runs them on a dedicated executor instead of on Gatling event-loop threads.
+
+By default, the plugin uses a bounded fixed thread pool, and `blockingPoolSize` defaults to the configured `maximumPoolSize`.
+This is the safe default for high-concurrency tests because it prevents unbounded native thread growth when JDBC calls pile up.
+
+### Scala
+
+```scala
+import org.galaxio.gatling.jdbc.Predef._
+
+val dataBase = DB
+  .url("jdbc:postgresql://localhost:5432/test")
+  .username("user")
+  .password("pass")
+  .maximumPoolSize(32)
+  .blockingPoolSize(32)
+```
+
+### Java
+
+```java
+var dataBase = DB()
+    .url("jdbc:postgresql://localhost:5432/test")
+    .username("user")
+    .password("pass")
+    .maximumPoolSize(32)
+    .blockingPoolSize(32)
+    .protocolBuilder();
+```
+
 ## Example Scenarios
 Examples [here](https://github.com/galax-io/gatling-jdbc-plugin/tree/master/src/test)
 
@@ -105,19 +137,4 @@ jdbc("select users")
         column("USER_ID").saveAs("userIds"),
         allResults().saveAs("rows")
     );
-```
-
-### Kotlin
-
-```kotlin
-import org.galaxio.gatling.javaapi.JdbcDsl.*
-
-jdbc("select users")
-    .query("SELECT ID AS USER_ID, NAME FROM USERS ORDER BY ID")
-    .check(
-        cell("NAME", 0).saveAs("firstName"),
-        row(0).saveAs("firstRow"),
-        column("USER_ID").saveAs("userIds"),
-        allResults().saveAs("rows")
-    )
 ```

--- a/src/main/java/org/galaxio/gatling/javaapi/protocol/JdbcProtocolBuilderConnectionSettingsStep.java
+++ b/src/main/java/org/galaxio/gatling/javaapi/protocol/JdbcProtocolBuilderConnectionSettingsStep.java
@@ -23,6 +23,10 @@ public class JdbcProtocolBuilderConnectionSettingsStep {
         return new JdbcProtocolBuilderConnectionSettingsStep(wrapped.minimumIdleConnections(newValue));
     }
 
+    public JdbcProtocolBuilderConnectionSettingsStep blockingPoolSize(Integer newValue){
+        return new JdbcProtocolBuilderConnectionSettingsStep(wrapped.blockingPoolSize(newValue));
+    }
+
     public JdbcProtocolBuilderConnectionSettingsStep connectionTimeout(Duration newValue){
         return new JdbcProtocolBuilderConnectionSettingsStep(wrapped.connectionTimeout(DurationConverters.toScala(newValue)));
     }

--- a/src/main/scala/org/galaxio/gatling/jdbc/protocol/JdbcProtocol.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/protocol/JdbcProtocol.scala
@@ -6,9 +6,22 @@ import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.protocol._
 import org.galaxio.gatling.jdbc.db._
 
-import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{Executors, ThreadFactory}
 
 object JdbcProtocol {
+  private final class JdbcThreadFactory(prefix: String) extends ThreadFactory {
+    private val delegate = Executors.defaultThreadFactory()
+    private val counter  = new AtomicInteger(0)
+
+    override def newThread(runnable: Runnable): Thread = {
+      val thread = delegate.newThread(runnable)
+      thread.setName(s"$prefix-${counter.incrementAndGet()}")
+      thread.setDaemon(true)
+      thread
+    }
+  }
+
   val jdbcProtocolKey: ProtocolKey[JdbcProtocol, JdbcComponents] = new ProtocolKey[JdbcProtocol, JdbcComponents] {
     override def protocolClass: Class[Protocol] = classOf[JdbcProtocol].asInstanceOf[Class[Protocol]]
 
@@ -17,7 +30,7 @@ object JdbcProtocol {
 
     override def newComponents(coreComponents: CoreComponents): JdbcProtocol => JdbcComponents =
       protocol => {
-        val blockingPool   = Executors.newCachedThreadPool()
+        val blockingPool   = Executors.newFixedThreadPool(protocol.blockingPoolSize, new JdbcThreadFactory("jdbc-blocking"))
         val connectionPool = new HikariDataSource(protocol.hikariConfig)
         JdbcComponents(JDBCClient(connectionPool, blockingPool))
       }
@@ -25,6 +38,6 @@ object JdbcProtocol {
 
 }
 
-case class JdbcProtocol(hikariConfig: HikariConfig) extends Protocol {
+case class JdbcProtocol(hikariConfig: HikariConfig, blockingPoolSize: Int) extends Protocol {
   type Components = JdbcComponents
 }

--- a/src/main/scala/org/galaxio/gatling/jdbc/protocol/JdbcProtocolBuider.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/protocol/JdbcProtocolBuider.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration._
 case object JdbcProtocolBuilderBase {
 
   def url(url: String): JdbcProtocolBuilderUsernameStep    = JdbcProtocolBuilderUsernameStep(url)
-  def hikariConfig(cfg: HikariConfig): JdbcProtocolBuilder = JdbcProtocolBuilder(cfg)
+  def hikariConfig(cfg: HikariConfig): JdbcProtocolBuilder = JdbcProtocolBuilder(cfg, cfg.getMaximumPoolSize)
 
 }
 
@@ -31,6 +31,7 @@ final case class JdbcProtocolBuilderConnectionSettingsStep(
     password: String,
     maximumPoolSize: Int = 10,
     minimumIdleConnections: Int = 10,
+    blockingPoolSize: Option[Int] = None,
     connectionTimeout: FiniteDuration = 1.minute,
 ) {
   def protocolBuilder: JdbcProtocolBuilder = {
@@ -43,19 +44,21 @@ final case class JdbcProtocolBuilderConnectionSettingsStep(
     hikariConfig.setMinimumIdle(minimumIdleConnections)
     hikariConfig.setConnectionTimeout(connectionTimeout.toMillis)
 
-    JdbcProtocolBuilder(hikariConfig)
+    JdbcProtocolBuilder(hikariConfig, blockingPoolSize.getOrElse(maximumPoolSize))
   }
 
   def maximumPoolSize(newValue: Int): JdbcProtocolBuilderConnectionSettingsStep              =
     this.copy(maximumPoolSize = newValue)
   def minimumIdleConnections(newValue: Int): JdbcProtocolBuilderConnectionSettingsStep       =
     this.copy(minimumIdleConnections = newValue)
+  def blockingPoolSize(newValue: Int): JdbcProtocolBuilderConnectionSettingsStep             =
+    this.copy(blockingPoolSize = Some(newValue))
   def connectionTimeout(newValue: FiniteDuration): JdbcProtocolBuilderConnectionSettingsStep =
     this.copy(connectionTimeout = newValue)
 }
 
-final case class JdbcProtocolBuilder(hikariConfig: HikariConfig) {
+final case class JdbcProtocolBuilder(hikariConfig: HikariConfig, blockingPoolSize: Int) {
 
-  def build: Protocol = JdbcProtocol(hikariConfig)
+  def build: Protocol = JdbcProtocol(hikariConfig, blockingPoolSize)
 
 }

--- a/src/test/scala/org/galaxio/gatling/jdbc/db/JDBCClientThreadingSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/db/JDBCClientThreadingSpec.scala
@@ -1,0 +1,102 @@
+package org.galaxio.gatling.jdbc.db
+
+import com.zaxxer.hikari.HikariDataSource
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.lang.reflect.{InvocationHandler, Proxy}
+import java.sql.{Connection, Statement}
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{CountDownLatch, ExecutorService, Executors, ThreadFactory, TimeUnit}
+
+class JDBCClientThreadingSpec extends AnyFlatSpec with Matchers {
+
+  private val requestCount = 48
+
+  "JDBCClient with bounded thread pool" should "cap worker growth under blocked JDBC calls" in {
+    val releaseConnections            = new CountDownLatch(1)
+    val blockingPoolSize              = 8
+    val startedConnections            = new CountDownLatch(blockingPoolSize)
+    val threadFactory                 = new CountingThreadFactory("jdbc-blocking")
+    val blockingPool: ExecutorService = Executors.newFixedThreadPool(blockingPoolSize, threadFactory)
+    val dataSource                    = new BlockingDataSource(startedConnections, releaseConnections)
+    val client                        = JDBCClient(dataSource, blockingPool)
+    val completions                   = new CountDownLatch(requestCount)
+
+    try {
+      (1 to requestCount).foreach { _ =>
+        client.executeRaw("SELECT 1")(
+          _ => completions.countDown(),
+          _ => completions.countDown(),
+        )
+      }
+
+      startedConnections.await(5, TimeUnit.SECONDS) shouldBe true
+
+      val workerThreadsCreated = threadFactory.createdCount.get()
+      workerThreadsCreated should be <= blockingPoolSize
+    } finally {
+      releaseConnections.countDown()
+      completions.await(5, TimeUnit.SECONDS)
+      client.close()
+    }
+  }
+
+  private final class CountingThreadFactory(prefix: String) extends ThreadFactory {
+    private val delegate            = Executors.defaultThreadFactory()
+    val createdCount: AtomicInteger = new AtomicInteger(0)
+
+    override def newThread(runnable: Runnable): Thread = {
+      val threadNumber = createdCount.incrementAndGet()
+      val thread       = delegate.newThread(runnable)
+      thread.setName(s"$prefix-$threadNumber")
+      thread
+    }
+  }
+
+  private final class BlockingDataSource(
+      startedConnections: CountDownLatch,
+      releaseConnections: CountDownLatch,
+  ) extends HikariDataSource {
+
+    private val statement: Statement = proxy[Statement] {
+      case "execute" => java.lang.Boolean.TRUE
+      case "close"   => null
+    }
+
+    private val connection: Connection = proxy[Connection] {
+      case "createStatement" => statement
+      case "close"           => null
+    }
+
+    override def getConnection: Connection = {
+      startedConnections.countDown()
+      releaseConnections.await(5, TimeUnit.SECONDS)
+      connection
+    }
+
+    override def close(): Unit = ()
+  }
+
+  private def proxy[T](handler: PartialFunction[String, AnyRef])(implicit clazz: reflect.ClassTag[T]): T = {
+    val invocationHandler = new InvocationHandler {
+      override def invoke(proxy: Any, method: java.lang.reflect.Method, args: Array[AnyRef]): AnyRef = {
+        if (handler.isDefinedAt(method.getName)) {
+          handler(method.getName)
+        } else {
+          method.getReturnType match {
+            case java.lang.Boolean.TYPE => java.lang.Boolean.FALSE
+            case java.lang.Integer.TYPE => Int.box(0)
+            case java.lang.Long.TYPE    => Long.box(0L)
+            case java.lang.Void.TYPE    => null
+            case _                      => null
+          }
+        }
+      }
+    }
+
+    Proxy
+      .newProxyInstance(clazz.runtimeClass.getClassLoader, Array(clazz.runtimeClass), invocationHandler)
+      .asInstanceOf[T]
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/jdbc/protocol/JdbcProtocolBuilderSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/protocol/JdbcProtocolBuilderSpec.scala
@@ -1,0 +1,37 @@
+package org.galaxio.gatling.jdbc.protocol
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration.DurationInt
+
+class JdbcProtocolBuilderSpec extends AnyFlatSpec with Matchers {
+
+  "JdbcProtocolBuilderConnectionSettingsStep" should "default blockingPoolSize to maximumPoolSize" in {
+    val builder = JdbcProtocolBuilderConnectionSettingsStep(
+      url = "jdbc:h2:mem:test",
+      username = "sa",
+      password = "",
+      maximumPoolSize = 12,
+    )
+
+    val protocol = builder.protocolBuilder.build.asInstanceOf[JdbcProtocol]
+
+    protocol.blockingPoolSize shouldBe 12
+  }
+
+  it should "allow overriding blockingPoolSize explicitly" in {
+    val builder = JdbcProtocolBuilderConnectionSettingsStep(
+      url = "jdbc:h2:mem:test",
+      username = "sa",
+      password = "",
+      maximumPoolSize = 12,
+      blockingPoolSize = Some(5),
+      connectionTimeout = 30.seconds,
+    )
+
+    val protocol = builder.protocolBuilder.build.asInstanceOf[JdbcProtocol]
+
+    protocol.blockingPoolSize shouldBe 5
+  }
+}


### PR DESCRIPTION
## What changed
- replaced the unbounded cached JDBC blocking executor with a bounded fixed thread pool
- made the blocking executor size configurable through the Scala and Java JDBC protocol builders with a safe default tied to `maximumPoolSize`
- added regression coverage for JDBC worker thread growth and protocol builder defaults
- documented the blocking executor behavior and tuning guidance in the README

## Why it changed
High-concurrency simulations were crashing with `Failed to start the native thread` because the plugin created an unbounded number of worker threads for blocking JDBC calls.

## Impact
The plugin now applies backpressure instead of creating unlimited native threads when JDBC calls pile up. Users can still tune the blocking executor size explicitly when needed.

## Root cause
`JdbcProtocol` used `Executors.newCachedThreadPool()` for blocking JDBC work, so each blocked request could cause another native thread to be created under load.

## Validation
- `sbt scalafmtAll scalafmtSbt`
- `sbt test`
