### PR TITLE
fix java/kotlin typed map values for inserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,35 @@ Java:
     .params(Map.of("id", "#{userId}")))
 ```
 
+### Java/Kotlin typed values in `params()` and `values()`
+
+Java and Kotlin map-based DSL methods preserve literal types such as `Boolean`, numeric values, UUIDs, and dates.
+String values still support Gatling EL, so you can mix typed literals and session expressions in the same map.
+
+Java:
+```java
+jdbc("insert user")
+    .insertInto("USERS", "id", "name", "active")
+    .values(Map.of(
+        "id", 1,
+        "name", "#{userName}",
+        "active", true
+    ));
+```
+
+Kotlin:
+```kotlin
+jdbc("insert user")
+    .insertInto("USERS", "id", "name", "active")
+    .values(
+        mapOf(
+            "id" to 1,
+            "name" to "#{userName}",
+            "active" to true,
+        )
+    )
+```
+
 ## Blocking Executor
 
 JDBC calls are blocking, so the plugin runs them on a dedicated executor instead of on Gatling event-loop threads.

--- a/src/main/java/org/galaxio/gatling/javaapi/internal/Utils.java
+++ b/src/main/java/org/galaxio/gatling/javaapi/internal/Utils.java
@@ -13,10 +13,17 @@ public final class Utils {
                         .entrySet()
                         .stream()
                         .map(pair ->
-                                scala.Tuple2.apply(pair.getKey(), Expressions.toExpression(pair.getValue().toString(), Object.class))
+                                scala.Tuple2.apply(pair.getKey(), toExpression(pair.getValue()))
                         ).toList()
                         .stream()
                         .toList())
                 .toSeq();
+    }
+
+    private static scala.Function1<io.gatling.core.session.Session, io.gatling.commons.validation.Validation<Object>> toExpression(Object value) {
+        if (value instanceof String stringValue) {
+            return Expressions.toExpression(stringValue, Object.class);
+        }
+        return Expressions.toStaticValueExpression(value);
     }
 }

--- a/src/test/java/org/galaxio/performance/jdbc/test/cases/JdbcActions.java
+++ b/src/test/java/org/galaxio/performance/jdbc/test/cases/JdbcActions.java
@@ -32,8 +32,17 @@ public class JdbcActions {
 
     public static DBInsertActionBuilder insertTest(){
         return jdbc("INSERT TEST")
-                .insertInto("TEST_TABLE", "id", "name")
-                .values(Map.of("id", 2, "name", "Test3"));
+                .insertInto("TEST_TABLE", "id", "name", "flag")
+                .values(Map.of("id", 2, "name", "Test3", "flag", true));
+    }
+
+    public static QueryActionBuilder selectInsertedTestBoolean() {
+        return jdbc("SELECT INSERTED TEST BOOLEAN")
+                .query("SELECT FLAG FROM TEST_TABLE WHERE ID = 2")
+                .check(
+                        simpleCheck(simpleCheckType.NonEmpty),
+                        cell("FLAG", 0).saveAs("insertedTestFlag")
+                );
     }
 
     public static DBCallActionBuilder callTest(){

--- a/src/test/java/org/galaxio/performance/jdbc/test/scenarios/JdbcBasicSimulation.java
+++ b/src/test/java/org/galaxio/performance/jdbc/test/scenarios/JdbcBasicSimulation.java
@@ -10,6 +10,13 @@ public class JdbcBasicSimulation {
             .exec(JdbcActions.createTable())
             .exec(JdbcActions.createprocedure())
             .exec(JdbcActions.insertTest())
+            .exec(JdbcActions.selectInsertedTestBoolean())
+            .exec(session -> {
+                if (!session.getBoolean("insertedTestFlag")) {
+                    throw new IllegalStateException("Expected insertedTestFlag to be true");
+                }
+                return session;
+            })
             .exec(JdbcActions.callTest())
             .exec(JdbcActions.batchTest())
             .exec(JdbcActions.selectTT())

--- a/src/test/kotlin/org/galaxio/performance/jdbc/test/cases/KtJdbcActions.kt
+++ b/src/test/kotlin/org/galaxio/performance/jdbc/test/cases/KtJdbcActions.kt
@@ -28,14 +28,23 @@ object KtJdbcActions {
 
     fun insertTest(): DBInsertActionBuilder {
         return jdbc("INSERT TEST")
-                .insertInto("TEST_TABLE", "id", "name")
-                .values(mapOf("id" to 2, "name" to "Test3"))
+                .insertInto("TEST_TABLE", "id", "name", "flag")
+                .values(mapOf("id" to 2, "name" to "Test3", "flag" to true))
     }
 
     fun callTest(): DBCallActionBuilder {
         return jdbc("CALL PROCEDURE TEST")
                 .call("TEST_PROCEDURE")
                 .params(mapOf("p1" to "value1", "p2" to 24L))
+    }
+
+    fun selectInsertedTestBoolean(): QueryActionBuilder {
+        return jdbc("SELECT INSERTED TEST BOOLEAN")
+            .query("SELECT FLAG FROM TEST_TABLE WHERE ID = 2")
+            .check(
+                simpleCheck(simpleCheckType.NonEmpty),
+                cell("FLAG", 0).saveAs("insertedTestFlag")
+            )
     }
 
     fun batchTest(): BatchActionBuilder {

--- a/src/test/kotlin/org/galaxio/performance/jdbc/test/scenarios/KtJdbcBasicSimulation.kt
+++ b/src/test/kotlin/org/galaxio/performance/jdbc/test/scenarios/KtJdbcBasicSimulation.kt
@@ -11,6 +11,11 @@ object KtJdbcBasicSimulation {
         .exec(KtJdbcActions.createTable())
         .exec(KtJdbcActions.createprocedure())
         .exec(KtJdbcActions.insertTest())
+        .exec(KtJdbcActions.selectInsertedTestBoolean())
+        .exec { session ->
+            check(session.getBoolean("insertedTestFlag")) { "Expected insertedTestFlag to be true" }
+            session
+        }
         .exec(KtJdbcActions.callTest())
         .exec(KtJdbcActions.batchTest())
         .exec(KtJdbcActions.selectTest())

--- a/src/test/scala/org/galaxio/gatling/javaapi/internal/UtilsJdbcIntegrationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/javaapi/internal/UtilsJdbcIntegrationSpec.scala
@@ -1,0 +1,105 @@
+package org.galaxio.gatling.javaapi.internal
+
+import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
+import io.gatling.commons.stats.OK
+import io.gatling.commons.validation.{Failure, Success}
+import io.gatling.core.session.Session
+import org.galaxio.gatling.jdbc.db.{JDBCClient, SQL}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.concurrent.Executors
+import java.util.{Map => JMap}
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Promise}
+
+class UtilsJdbcIntegrationSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+
+  private val hikariConfig = new HikariConfig()
+  hikariConfig.setJdbcUrl("jdbc:h2:mem:java-utils-integration;DB_CLOSE_DELAY=-1")
+  hikariConfig.setUsername("sa")
+  hikariConfig.setPassword("")
+
+  private val dataSource  = new HikariDataSource(hikariConfig)
+  private val jdbcClient  = JDBCClient(dataSource, Executors.newFixedThreadPool(2))
+  private val awaitWindow = 5.seconds
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    val connection = dataSource.getConnection
+    val statement  = connection.createStatement()
+    try {
+      statement.execute("CREATE TABLE JAVA_BOOL_TEST (ID INT PRIMARY KEY, NAME VARCHAR(64), FLAG BOOLEAN)")
+    } finally {
+      statement.close()
+      connection.close()
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    jdbcClient.close()
+    super.afterAll()
+  }
+
+  private def session(attributes: Map[String, Any] = scala.collection.immutable.Map.empty): Session =
+    new Session("utils-jdbc-integration-spec", 1L, attributes, OK, Nil, Session.NothingOnExit, null)
+
+  private def evaluatedParams(values: JMap[String, Object], sessionAttributes: Map[String, Any] = Map.empty): Map[String, Any] =
+    Utils
+      .getSeq(values)
+      .map { case (key, expression) =>
+        val value = expression(session(sessionAttributes)) match {
+          case Success(v)     => v
+          case Failure(error) => fail(error)
+        }
+        key -> value
+      }
+      .toMap
+
+  "Java map values" should "insert boolean literals without coercing them to strings" in {
+    val cleanupConnection = dataSource.getConnection
+    val cleanupStatement  = cleanupConnection.createStatement()
+    try {
+      cleanupStatement.execute("DELETE FROM JAVA_BOOL_TEST")
+    } finally {
+      cleanupStatement.close()
+      cleanupConnection.close()
+    }
+
+    val params = evaluatedParams(
+      JMap.of(
+        "id",
+        Int.box(1),
+        "name",
+        "#{userName}",
+        "flag",
+        Boolean.box(true),
+      ),
+      Map("userName" -> "Alice"),
+    )
+
+    val sql     = SQL("INSERT INTO JAVA_BOOL_TEST (ID, NAME, FLAG) VALUES({id}, {name}, {flag})").withParamsMap(params)
+    val promise = Promise[Int]()
+
+    jdbcClient.executeUpdate(sql.sql, sql.params)(
+      updatedRows => promise.success(updatedRows),
+      error => promise.failure(error),
+    )
+
+    Await.result(promise.future, awaitWindow) shouldBe 1
+
+    val connection = dataSource.getConnection
+    val statement  = connection.createStatement()
+
+    try {
+      val resultSet = statement.executeQuery("SELECT NAME, FLAG FROM JAVA_BOOL_TEST WHERE ID = 1")
+      resultSet.next() shouldBe true
+      resultSet.getString("NAME") shouldBe "Alice"
+      resultSet.getBoolean("FLAG") shouldBe true
+    } finally {
+      statement.close()
+      connection.close()
+    }
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/javaapi/internal/UtilsSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/javaapi/internal/UtilsSpec.scala
@@ -1,0 +1,38 @@
+package org.galaxio.gatling.javaapi.internal
+
+import io.gatling.commons.stats.OK
+import io.gatling.commons.validation.Success
+import io.gatling.core.session.Session
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.{Map => JMap}
+
+class UtilsSpec extends AnyFlatSpec with Matchers {
+
+  private def session(attributes: Map[String, Any] = scala.collection.immutable.Map.empty): Session =
+    new Session("utils-spec", 1L, attributes, OK, Nil, Session.NothingOnExit, null)
+
+  private def expressionFor(
+      expressions: scala.collection.immutable.Seq[
+        (String, Session => io.gatling.commons.validation.Validation[Object]),
+      ],
+      key: String,
+  ): Session => io.gatling.commons.validation.Validation[Object] =
+    expressions.collectFirst { case (`key`, expression) => expression }.getOrElse(fail(s"Missing expression for '$key'"))
+
+  "Utils.getSeq" should "preserve typed literal values from Java maps" in {
+    val expressions = Utils.getSeq(JMap.of("flag", Boolean.box(true), "id", Int.box(2)))
+
+    expressionFor(expressions, "flag")(session()) shouldBe Success(true)
+    expressionFor(expressions, "id")(session()) shouldBe Success(2)
+  }
+
+  it should "still resolve Gatling EL expressions from Java string values" in {
+    val expressions = Utils.getSeq(JMap.of("id", "#{userId}", "name", "Alice"))
+    val testSession = session(Map("userId" -> 42))
+
+    expressionFor(expressions, "id")(testSession) shouldBe Success(42)
+    expressionFor(expressions, "name")(testSession) shouldBe Success("Alice")
+  }
+}


### PR DESCRIPTION
## Summary
- preserve typed Java/Kotlin map values instead of coercing every value to String in the Java API bridge
- keep EL parsing for String values while passing Boolean and other literals through as typed expressions
- add unit and H2-backed integration coverage for the Java bridge and document typed `params()` / `values()` usage

## Verification
- sbt scalafmtAll scalafmtSbt
- sbt test
- sbt 'Gatling / testOnly org.galaxio.performance.jdbc.test.DebugTest'
