### PR TITLE
feat: production-ready — transactions, pool metrics, testcontainers, CI overhaul

### DIFF
--- a/.github/changelog/release-changelog-builder.json
+++ b/.github/changelog/release-changelog-builder.json
@@ -1,0 +1,22 @@
+{
+  "template": "# Changelog\n\n#{{CHANGELOG}}",
+  "categories": [
+    {"title": "✨ Features", "labels": ["feat", "feature"]},
+    {"title": "🐛 Bug Fixes", "labels": ["fix", "bug"]},
+    {"title": "📝 Documentation", "labels": ["docs"]},
+    {"title": "⚡ Performance Improvements", "labels": ["perf"]},
+    {"title": "♻️ Refactoring", "labels": ["refactor"]},
+    {"title": "🧪 Tests", "labels": ["test"]},
+    {"title": "🧹 Chores", "labels": ["chore"]},
+    {"title": "📦 Dependencies", "labels": ["dependency"]},
+    {"title": "🚨 Breaking Changes", "labels": ["breaking"]},
+    {"title": "🤖 CI / Build", "labels": ["ci"]}
+  ],
+  "label_extractor": [
+    {
+      "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)",
+      "on_property": "title",
+      "target": "$1"
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,12 @@ on:
   pull_request:
     branches: ['**']
   push:
-    branches: ['**']
+    branches: ['main']
     tags: ['v*']
+  workflow_dispatch:
 
 permissions:
-  contents: write
-  actions: read
-  checks: write
-  pull-requests: write
-  packages: write
+  contents: read
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -26,67 +23,147 @@ env:
   TERM: xterm-256color
 
 jobs:
-  test:
-    name: Lint, Compile & Test
+  format:
+    name: Formatting
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Setup Java (Temurin 17) with sbt cache
-        uses: actions/setup-java@v4
+        uses: actions/checkout@v6
+
+      - name: Setup Java (Temurin 17)
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
           cache: sbt
-      - uses: sbt/setup-sbt@v1
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
       - name: Cache Coursier
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
+
+      - name: Check Formatting
+        run: sbt scalafmtCheckAll scalafmtSbtCheck
+
+  test:
+    name: Test (Java ${{ matrix.java }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        java: ['17', '21']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java (Temurin ${{ matrix.java }})
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+          cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Cache Coursier
+        uses: coursier/cache-action@v8
+
       - name: Cache Ivy/SBT
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.ivy2/cache
             ~/.sbt
             ~/.cache/coursier
-          key: sbt-${{ runner.os }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/**') }}
-          restore-keys: sbt-${{ runner.os }}-
-      - name: Check Formatting
-        run: sbt scalafmtCheckAll scalafmtSbtCheck
+          key: sbt-${{ runner.os }}-java${{ matrix.java }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/**') }}
+          restore-keys: sbt-${{ runner.os }}-java${{ matrix.java }}-
+
       - name: Compile
-        run: sbt clean compile
-      - name: Tests (including Gatling JDBC example on H2)
-        run: sbt coverage "Gatling / testOnly org.galaxio.performance.jdbc.test.DebugTest" test coverageReport coverageOff
+        run: sbt compile
+
+      - name: Unit Tests with Coverage
+        run: sbt coverage test coverageReport coverageOff
+
+      - name: Gatling Simulation (H2)
+        run: sbt "Gatling / testOnly org.galaxio.performance.jdbc.test.DebugTest"
+
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        if: matrix.java == '17'
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: false
 
+  integration:
+    name: Integration Tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java (Temurin 21)
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: sbt
+
+      - name: Setup sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Cache Coursier
+        uses: coursier/cache-action@v8
+
+      - name: Cache Ivy/SBT
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+            ~/.cache/coursier
+          key: sbt-${{ runner.os }}-java21-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/**') }}
+          restore-keys: sbt-${{ runner.os }}-java21-
+
+      - name: Integration Tests (Testcontainers)
+        run: sbt "Test / testOnly -- -n org.galaxio.gatling.jdbc.tags.DockerTest"
+
   release:
     name: Release (tag-driven)
-    needs: [test]
+    needs: [format, test, integration]
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     permissions:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Setup Java (Temurin 17) with sbt cache
-        uses: actions/setup-java@v4
+
+      - name: Setup Java (Temurin 17)
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
           cache: sbt
+
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
+
       - name: Cache Coursier
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
+
       - name: Cache Ivy/SBT
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.ivy2/cache
@@ -94,6 +171,7 @@ jobs:
             ~/.cache/coursier
           key: sbt-${{ runner.os }}-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/**') }}
           restore-keys: sbt-${{ runner.os }}-
+
       - name: Compute next version & create tag on main
         id: bump
         if: github.ref == 'refs/heads/main'
@@ -156,6 +234,7 @@ jobs:
             git tag -a "$NEXT_TAG" -m "Release $NEXT_TAG"
             git push origin "$NEXT_TAG"
           fi
+
       - name: Publish to Sonatype via sbt-ci-release
         if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main' && steps.bump.outputs.tag)
         env:
@@ -187,44 +266,24 @@ jobs:
           else
             sbt "set ThisBuild/version := \"${VERSION}\"" ci-release
           fi
+
       - name: Generate Changelog
         id: changelog
-        uses: mikepenz/release-changelog-builder-action@v5
+        uses: mikepenz/release-changelog-builder-action@v6
         if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main' && steps.bump.outputs.tag)
         with:
           mode: "COMMIT"
           fromTag: ${{ github.ref == 'refs/heads/main' && steps.bump.outputs.last_tag || '' }}
           toTag:   ${{ github.ref == 'refs/heads/main' && steps.bump.outputs.tag || '' }}
-          configurationJson: |
-            {
-              "template": "# Changelog\n\n#{{CHANGELOG}}",
-              "categories": [
-                {"title": "✨ Features", "labels": ["feat", "feature"]},
-                {"title": "🐛 Bug Fixes", "labels": ["fix", "bug"]},
-                {"title": "📝 Documentation", "labels": ["docs"]},
-                {"title": "⚡ Performance Improvements", "labels": ["perf"]},
-                {"title": "♻️ Refactoring", "labels": ["refactor"]},
-                {"title": "🧪 Tests", "labels": ["test"]},
-                {"title": "🧹 Chores", "labels": ["chore"]},
-                {"title": "📦 Dependencies", "labels": ["dependency"]},
-                {"title": "🚨 Breaking Changes", "labels": ["breaking"]},
-                {"title": "🤖 CI / Build", "labels": ["ci"]}
-              ],
-              "label_extractor": [
-                {
-                  "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test){1}(\\([\\w\\-\\.]+\\))?(!)?: ([\\w ])+([\\s\\S]*)",
-                  "on_property": "title",
-                  "target": "$1"
-                }
-              ]
-            }
+          configuration: ".github/changelog/release-changelog-builder.json"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main' && steps.bump.outputs.tag)
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ github.ref == 'refs/heads/main' && steps.bump.outputs.tag || '' }}
+          tag_name: ${{ github.ref == 'refs/heads/main' && steps.bump.outputs.tag || github.ref_name }}
           body: ${{ steps.changelog.outputs.changelog }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,95 +1,38 @@
 # Gatling JDBC Plugin
-[![CI](https://github.com/galax-io/gatling-jdbc-plugin/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/galax-io/gatling-jdbc-plugin/actions/workflows/ci.yml) [![Maven Central](https://img.shields.io/maven-central/v/org.galaxio/gatling-jdbc-plugin_2.13.svg?color=success)](https://search.maven.org/search?q=org.galaxio.gatling-jdbc-plugin) [![Scala Steward badge](https://img.shields.io/badge/Scala_Steward-helping-blue.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAAVFBMVEUAAACHjojlOy5NWlrKzcYRKjGFjIbp293YycuLa3pYY2LSqql4f3pCUFTgSjNodYRmcXUsPD/NTTbjRS+2jomhgnzNc223cGvZS0HaSD0XLjbaSjElhIr+AAAAAXRSTlMAQObYZgAAAHlJREFUCNdNyosOwyAIhWHAQS1Vt7a77/3fcxxdmv0xwmckutAR1nkm4ggbyEcg/wWmlGLDAA3oL50xi6fk5ffZ3E2E3QfZDCcCN2YtbEWZt+Drc6u6rlqv7Uk0LdKqqr5rk2UCRXOk0vmQKGfc94nOJyQjouF9H/wCc9gECEYfONoAAAAASUVORK5CYII=)](https://scala-steward.org) [![codecov.io](https://codecov.io/github/galax-io/gatling-jdbc-plugin/coverage.svg?branch=master)](https://codecov.io/github/galax-io/gatling-jdbc-plugin?branch=master)
 
-Plugin for support performance testing with JDBC in Gatling(3.9.x)
+[![CI](https://github.com/galax-io/gatling-jdbc-plugin/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/galax-io/gatling-jdbc-plugin/actions/workflows/ci.yml)
+[![Maven Central](https://img.shields.io/maven-central/v/org.galaxio/gatling-jdbc-plugin_2.13.svg?color=success)](https://search.maven.org/search?q=org.galaxio.gatling-jdbc-plugin)
+[![Scala Steward badge](https://img.shields.io/badge/Scala_Steward-helping-blue.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAAVFBMVEUAAACHjojlOy5NWlrKzcYRKjGFjIbp293YycuLa3pYY2LSqql4f3pCUFTgSjNodYRmcXUsPD/NTTbjRS+2jomhgnzNc223cGvZS0HaSD0XLjbaSjElhIr+AAAAAXRSTlMAQObYZgAAAHlJREFUCNdNyosOwyAIhWHAQS1Vt7a77/3fcxxdmv0xwmckutAR1nkm4ggbyEcg/wWmlGLDAA3oL50xi6fk5ffZ3E2E3QfZDCcCN2YtbEWZt+Drc6u6rlqv7Uk0LdKqqr5rk2UCRXOk0vmQKGfc94nOJyQjouF9H/wCc9gECEYfONoAAAAASUVORK5CYII=)](https://scala-steward.org)
+[![codecov](https://codecov.io/github/galax-io/gatling-jdbc-plugin/coverage.svg?branch=main)](https://codecov.io/github/galax-io/gatling-jdbc-plugin?branch=main)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
-# Usage
+JDBC protocol plugin for [Gatling](https://gatling.io/) load testing framework. Execute SQL queries, inserts, updates, batch operations, and stored procedures against any JDBC-compatible database with connection pooling (HikariCP) and result checks.
 
-## Getting Started
-Plugin is currently available for Scala 2.13.
+Requires Scala 2.13, Java 17+, Gatling 3.11+.
 
-You may add plugin as dependency in project with your tests. Write this to your build.sbt:
+## Installation
 
-``` scala
-libraryDependencies += "org.galaxio" %% "gatling-jdbc-plugin" % <version> % Test
-``` 
-
-## Using Gatling Session Variables
-
-The plugin supports [Gatling Expression Language (EL)](https://docs.gatling.io/reference/script/core/session/el/) in SQL queries.
-Use `#{variableName}` to reference values stored in the Gatling session.
-
-### `query()` with EL
-
-Scala:
-``` scala
-exec(session => session.set("tableName", "USERS"))
-.exec(jdbc("dynamic query").query("SELECT * FROM #{tableName} WHERE id = #{id}"))
+**sbt**:
+```scala
+libraryDependencies += "org.galaxio" %% "gatling-jdbc-plugin" % "<version>" % Test
 ```
 
-Java:
-``` java
-.exec(session -> session.set("tableName", "USERS"))
-.exec(jdbc("dynamic query").query("SELECT * FROM #{tableName} WHERE id = #{id}"))
+**Maven**:
+```xml
+<dependency>
+  <groupId>org.galaxio</groupId>
+  <artifactId>gatling-jdbc-plugin_2.13</artifactId>
+  <version>${version}</version>
+  <scope>test</scope>
+</dependency>
 ```
 
-### `queryP()` with EL
-
-`queryP` uses two different syntaxes:
-- `{param}` in SQL string — prepared statement placeholder (replaced with `?`)
-- `"#{var}"` in `.params()` — Gatling EL, resolves value from session at runtime
-
-Scala:
-``` scala
-exec(
-  jdbc("parameterized query")
-    .queryP("SELECT * FROM TEST_TABLE WHERE id = {id}")
-    .params("id" -> "#{userId}")
-)
-```
-
-Java:
-``` java
-.exec(jdbc("parameterized query")
-    .queryP("SELECT * FROM TEST_TABLE WHERE id = {id}")
-    .params(Map.of("id", "#{userId}")))
-```
-
-### Java/Kotlin typed values in `params()` and `values()`
-
-Java and Kotlin map-based DSL methods preserve literal types such as `Boolean`, numeric values, UUIDs, and dates.
-String values still support Gatling EL, so you can mix typed literals and session expressions in the same map.
-
-Java:
-```java
-jdbc("insert user")
-    .insertInto("USERS", "id", "name", "active")
-    .values(Map.of(
-        "id", 1,
-        "name", "#{userName}",
-        "active", true
-    ));
-```
-
-Kotlin:
+**Gradle (Kotlin DSL)**:
 ```kotlin
-jdbc("insert user")
-    .insertInto("USERS", "id", "name", "active")
-    .values(
-        mapOf(
-            "id" to 1,
-            "name" to "#{userName}",
-            "active" to true,
-        )
-    )
+gatling("org.galaxio:gatling-jdbc-plugin_2.13:<version>")
 ```
 
-## Blocking Executor
-
-JDBC calls are blocking, so the plugin runs them on a dedicated executor instead of on Gatling event-loop threads.
-
-By default, the plugin uses a bounded fixed thread pool, and `blockingPoolSize` defaults to the configured `maximumPoolSize`.
-This is the safe default for high-concurrency tests because it prevents unbounded native thread growth when JDBC calls pile up.
+## Protocol Configuration
 
 ### Scala
 
@@ -102,6 +45,7 @@ val dataBase = DB
   .password("pass")
   .maximumPoolSize(32)
   .blockingPoolSize(32)
+  .queryTimeout(30.seconds)
 ```
 
 ### Java
@@ -113,51 +57,106 @@ var dataBase = DB()
     .password("pass")
     .maximumPoolSize(32)
     .blockingPoolSize(32)
+    .queryTimeout(Duration.ofSeconds(30))
     .protocolBuilder();
 ```
 
 ### Kotlin
 
 ```kotlin
-import org.galaxio.gatling.javaapi.JdbcDsl.DB
-import org.galaxio.gatling.javaapi.protocol.JdbcProtocolBuilder
-
-val dataBase: JdbcProtocolBuilder = DB()
+val dataBase = DB()
     .url("jdbc:postgresql://localhost:5432/test")
     .username("user")
     .password("pass")
     .maximumPoolSize(32)
     .blockingPoolSize(32)
+    .queryTimeout(Duration.ofSeconds(30))
     .protocolBuilder()
 ```
 
-## Example Scenarios
-Examples [here](https://github.com/galax-io/gatling-jdbc-plugin/tree/master/src/test)
+### Connection Pool Settings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `maximumPoolSize` | 10 | Max connections in HikariCP pool |
+| `minimumIdleConnections` | 10 | Min idle connections |
+| `blockingPoolSize` | = `maximumPoolSize` | Fixed thread pool for blocking JDBC calls |
+| `connectionTimeout` | 1 minute | Connection acquisition timeout |
+| `queryTimeout` | None | Statement query timeout (per query) |
+
+JDBC calls are blocking, so the plugin runs them on a dedicated executor. `blockingPoolSize` defaults to `maximumPoolSize` to prevent unbounded native thread growth.
+
+### Custom HikariConfig
+
+```scala
+val hikariConfig = new HikariConfig()
+hikariConfig.setJdbcUrl("jdbc:postgresql://localhost:5432/test")
+hikariConfig.setMaximumPoolSize(16)
+// ... any HikariCP settings
+
+val dataBase = DB.hikariConfig(hikariConfig)
+```
+
+## Using Gatling Session Variables
+
+The plugin supports [Gatling Expression Language (EL)](https://docs.gatling.io/reference/script/core/session/el/) in SQL queries.
+Use `#{variableName}` to reference values stored in the Gatling session.
+
+### `query()` with EL
+
+```scala
+exec(session => session.set("tableName", "USERS"))
+.exec(jdbc("dynamic query").query("SELECT * FROM #{tableName} WHERE id = #{id}"))
+```
+
+### `queryP()` with EL
+
+`queryP` uses two different syntaxes:
+- `{param}` in SQL string — prepared statement placeholder (replaced with `?`)
+- `"#{var}"` in `.params()` — Gatling EL, resolves value from session at runtime
+
+```scala
+exec(
+  jdbc("parameterized query")
+    .queryP("SELECT * FROM TEST_TABLE WHERE id = {id}")
+    .params("id" -> "#{userId}")
+)
+```
+
+### Java/Kotlin typed values in `params()` and `values()`
+
+Java and Kotlin map-based DSL methods preserve literal types such as `Boolean`, numeric values, UUIDs, and dates.
+String values still support Gatling EL, so you can mix typed literals and session expressions in the same map.
+
+```java
+jdbc("insert user")
+    .insertInto("USERS", "id", "name", "active")
+    .values(Map.of(
+        "id", 1,
+        "name", "#{userName}",
+        "active", true
+    ));
+```
 
 ## Inspecting Query Results
 
-JDBC query checks operate on a result set represented as a list of rows, where each row is a map keyed by the SQL column label:
-
-- Scala session type saved by `allResults.saveAs("rows")`: `List[Map[String, Any]]`
-- Java/Kotlin session type saved by `allResults().saveAs("rows")`: Scala immutable collections exposed through Gatling's Java API
-
-Column aliases are supported. For example, `SELECT user_id AS id` makes the value available under `id`.
+JDBC query checks operate on a result set represented as `List[Map[String, Any]]`.
 
 ### Available Result Checks
 
-- `allResults` / `allResults()` - extract the full result set
-- `row(index)` - extract a single row by zero-based index
-- `column(name)` - extract all values from a column
-- `cell(name, rowIndex)` - extract a single value from a column at the given zero-based row index
+| Check | Description |
+|-------|-------------|
+| `allResults` / `allResults()` | Full result set |
+| `row(index)` | Single row by zero-based index |
+| `column(name)` | All values from a column |
+| `cell(name, rowIndex)` | Single value at column + row |
+| `simpleCheck(predicate)` | Custom boolean predicate |
 
 When a row index or column name is invalid, the check fails with a descriptive error message.
 
 ### Scala
 
 ```scala
-import io.gatling.core.Predef._
-import org.galaxio.gatling.jdbc.Predef._
-
 jdbc("select users")
   .query("SELECT ID AS USER_ID, NAME FROM USERS ORDER BY ID")
   .check(
@@ -171,8 +170,6 @@ jdbc("select users")
 ### Java
 
 ```java
-import static org.galaxio.gatling.javaapi.JdbcDsl.*;
-
 jdbc("select users")
     .query("SELECT ID AS USER_ID, NAME FROM USERS ORDER BY ID")
     .check(
@@ -183,17 +180,66 @@ jdbc("select users")
     );
 ```
 
-### Kotlin
+## Transactions
 
-```kotlin
-import org.galaxio.gatling.javaapi.JdbcDsl.*
+Execute multiple SQL statements in a single JDBC transaction with automatic commit/rollback.
+If any statement fails, the entire transaction is rolled back.
 
-jdbc("select users")
-    .query("SELECT ID AS USER_ID, NAME FROM USERS ORDER BY ID")
-    .check(
-        cell("NAME", 0).saveAs("firstName"),
-        row(0).saveAs("firstRow"),
-        column("USER_ID").saveAs("userIds"),
-        allResults().saveAs("rows")
-    )
+### Scala
+
+```scala
+jdbc("transfer funds").transaction(
+  "UPDATE accounts SET balance = balance - 100 WHERE id = 1",
+  "UPDATE accounts SET balance = balance + 100 WHERE id = 2",
+  "INSERT INTO audit_log (action) VALUES ('transfer')",
+)
 ```
+
+### Java / Kotlin
+
+```java
+jdbc("transfer funds").transaction(
+    "UPDATE accounts SET balance = balance - 100 WHERE id = 1",
+    "UPDATE accounts SET balance = balance + 100 WHERE id = 2",
+    "INSERT INTO audit_log (action) VALUES ('transfer')"
+);
+```
+
+Gatling EL expressions (`#{varName}`) are supported in transaction statements.
+
+## Connection Pool Metrics
+
+HikariCP pool metrics (active, idle, waiting, total connections) are logged automatically when the simulation ends.
+This helps diagnose pool exhaustion or connection leaks during load tests.
+
+## Examples
+
+- [Scala](src/test/scala/org/galaxio/performance/jdbc/test)
+- [Java](src/test/java/org/galaxio/performance/jdbc/test)
+- [Kotlin](src/test/kotlin/org/galaxio/performance/jdbc/test)
+
+## Contributing
+
+```bash
+# Build
+sbt compile
+
+# Run unit tests
+sbt test
+
+# Run integration tests (requires Docker)
+sbt "Test / testOnly -- -n org.galaxio.gatling.jdbc.tags.DockerTest"
+
+# Run Gatling example simulation (H2)
+sbt "Gatling / testOnly org.galaxio.performance.jdbc.test.DebugTest"
+
+# Check formatting
+sbt scalafmtCheckAll
+
+# Format code
+sbt scalafmtAll
+```
+
+## License
+
+Apache License 2.0. See [LICENSE](LICENSE) for details.

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,14 @@ lazy val root = (project in file("."))
     GatlingIt / publishArtifact := false,
     libraryDependencies ++= gatling ++ gatlingCore,
     libraryDependencies ++= Seq(hikari, h2jdbc, scalatest),
+    libraryDependencies ++= Seq(
+      testcontainersScalatest,
+      testcontainersPostgres,
+      testcontainersMysql,
+      postgresql,
+      mysql,
+    ),
+    Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-l", "org.galaxio.gatling.jdbc.tags.DockerTest"),
     scalacOptions ++= Seq(
       "-encoding",
       "UTF-8",            // Option and arguments on same line

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,4 +18,11 @@ object Dependencies {
   lazy val h2jdbc    = "com.h2database" % "h2"        % "2.4.240" % Test
   lazy val scalatest = "org.scalatest" %% "scalatest" % "3.2.19"  % Test
 
+  lazy val testcontainersScalatest = "com.dimafeng" %% "testcontainers-scala-scalatest"  % "0.41.8" % Test
+  lazy val testcontainersPostgres  = "com.dimafeng" %% "testcontainers-scala-postgresql" % "0.41.8" % Test
+  lazy val testcontainersMysql     = "com.dimafeng" %% "testcontainers-scala-mysql"      % "0.41.8" % Test
+
+  lazy val postgresql = "org.postgresql" % "postgresql"        % "42.7.7" % Test
+  lazy val mysql      = "com.mysql"      % "mysql-connector-j" % "9.3.0"  % Test
+
 }

--- a/src/main/java/org/galaxio/gatling/javaapi/actions/DBBaseAction.java
+++ b/src/main/java/org/galaxio/gatling/javaapi/actions/DBBaseAction.java
@@ -41,6 +41,15 @@ public final class DBBaseAction{
         return new QueryActionBuilder(wrapped.query(Expressions.toStringExpression(sql)));
     }
 
+    public TransactionActionBuilder transaction(String... statements) {
+        return new TransactionActionBuilder(
+            wrapped.transaction(
+                asScala(Arrays.stream(statements)
+                    .map(Expressions::toStringExpression)
+                    .toList()).toSeq()
+            ));
+    }
+
     public BatchActionBuilder batch(BatchAction... actions) {
         return new BatchActionBuilder(
             wrapped.batch(

--- a/src/main/java/org/galaxio/gatling/javaapi/actions/TransactionActionBuilder.java
+++ b/src/main/java/org/galaxio/gatling/javaapi/actions/TransactionActionBuilder.java
@@ -1,0 +1,16 @@
+package org.galaxio.gatling.javaapi.actions;
+
+import io.gatling.javaapi.core.ActionBuilder;
+
+public class TransactionActionBuilder implements ActionBuilder {
+    private final org.galaxio.gatling.jdbc.actions.actions.TransactionActionBuilder wrapped;
+
+    public TransactionActionBuilder(org.galaxio.gatling.jdbc.actions.actions.TransactionActionBuilder wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public io.gatling.core.action.builder.ActionBuilder asScala() {
+        return this.wrapped;
+    }
+}

--- a/src/main/java/org/galaxio/gatling/javaapi/protocol/JdbcProtocolBuilderConnectionSettingsStep.java
+++ b/src/main/java/org/galaxio/gatling/javaapi/protocol/JdbcProtocolBuilderConnectionSettingsStep.java
@@ -30,4 +30,8 @@ public class JdbcProtocolBuilderConnectionSettingsStep {
     public JdbcProtocolBuilderConnectionSettingsStep connectionTimeout(Duration newValue){
         return new JdbcProtocolBuilderConnectionSettingsStep(wrapped.connectionTimeout(DurationConverters.toScala(newValue)));
     }
+
+    public JdbcProtocolBuilderConnectionSettingsStep queryTimeout(Duration newValue){
+        return new JdbcProtocolBuilderConnectionSettingsStep(wrapped.queryTimeout(DurationConverters.toScala(newValue)));
+    }
 }

--- a/src/main/scala/org/galaxio/gatling/jdbc/actions/DBTransactionAction.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/actions/DBTransactionAction.scala
@@ -1,0 +1,67 @@
+package org.galaxio.gatling.jdbc.actions
+
+import io.gatling.commons.stats.{KO, OK}
+import io.gatling.commons.validation._
+import io.gatling.core.action.{Action, ChainableAction}
+import io.gatling.core.session.{Expression, Session}
+import io.gatling.core.stats.StatsEngine
+import io.gatling.core.structure.ScenarioContext
+import io.gatling.core.util.NameGen
+
+case class DBTransactionAction(
+    requestName: Expression[String],
+    statements: Seq[Expression[String]],
+    ctx: ScenarioContext,
+    next: Action,
+) extends ChainableAction with NameGen with ActionBase {
+  override def name: String = genName("jdbcTransactionAction")
+
+  override def execute(session: Session): Unit = {
+    val resolvedStmts = statements.foldLeft(Seq.empty[String].success) { (acc, expr) =>
+      for {
+        resolved <- acc
+        stmt     <- expr(session)
+      } yield resolved :+ stmt
+    }
+
+    (for {
+      resolvedName <- requestName(session)
+      stmts        <- resolvedStmts
+      startTime    <- ctx.coreComponents.clock.nowMillis.success
+    } yield dbClient
+      .executeTransaction(stmts)(
+        _ => executeNext(session, startTime, ctx.coreComponents.clock.nowMillis, OK, next, resolvedName, None, None),
+        exception =>
+          executeNext(
+            session,
+            startTime,
+            ctx.coreComponents.clock.nowMillis,
+            KO,
+            next,
+            resolvedName,
+            Some("ERROR"),
+            Some(exception.getMessage),
+          ),
+      )).onFailure { m =>
+      val message =
+        if (m.contains("No attribute named"))
+          s"$m. Hint: ensure Gatling EL variable (e.g. #{varName}) is set in session before this action"
+        else m
+      requestName(session).map { rn =>
+        ctx.coreComponents.statsEngine.logRequestCrash(session.scenario, session.groups, rn, message)
+        executeNext(
+          session,
+          ctx.coreComponents.clock.nowMillis,
+          ctx.coreComponents.clock.nowMillis,
+          KO,
+          next,
+          rn,
+          Some("ERROR"),
+          Some(message),
+        )
+      }
+    }
+  }
+
+  override def statsEngine: StatsEngine = ctx.coreComponents.statsEngine
+}

--- a/src/main/scala/org/galaxio/gatling/jdbc/actions/actions.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/actions/actions.scala
@@ -14,9 +14,11 @@ object actions {
 
     def rawSql(queryString: Expression[String]): RawSqlActionBuilder = RawSqlActionBuilder(requestName, queryString)
 
-    def queryP(sql: Expression[String]): QueryActionParamsStep = QueryActionParamsStep(requestName, sql)
-    def query(sql: Expression[String]): QueryActionBuilder     = QueryActionBuilder(requestName, sql, params = Seq.empty)
-    def batch(actions: BatchAction*): BatchActionBuilder       = BatchActionBuilder(requestName, actions)
+    def queryP(sql: Expression[String]): QueryActionParamsStep            = QueryActionParamsStep(requestName, sql)
+    def query(sql: Expression[String]): QueryActionBuilder                = QueryActionBuilder(requestName, sql, params = Seq.empty)
+    def batch(actions: BatchAction*): BatchActionBuilder                  = BatchActionBuilder(requestName, actions)
+    def transaction(stmts: Expression[String]*): TransactionActionBuilder =
+      TransactionActionBuilder(requestName, stmts)
   }
 
   final case class BatchInsertBaseAction(tableName: Expression[String], columns: Columns) {
@@ -110,5 +112,13 @@ object actions {
 
   final case class BatchActionBuilder(batchName: Expression[String], actions: Seq[BatchAction]) extends ActionBuilder {
     override def build(ctx: ScenarioContext, next: Action): Action = DBBatchAction(batchName, actions, next, ctx)
+  }
+
+  case class TransactionActionBuilder(
+      requestName: Expression[String],
+      statements: Seq[Expression[String]],
+  ) extends ActionBuilder {
+    override def build(ctx: ScenarioContext, next: Action): Action =
+      DBTransactionAction(requestName, statements, ctx, next)
   }
 }

--- a/src/main/scala/org/galaxio/gatling/jdbc/db/ConnectionWrapper.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/db/ConnectionWrapper.scala
@@ -10,6 +10,7 @@ trait ConnectionWrapper[F[_]] {
   def getAutoCommit: F[Boolean]
   def setAutoCommit(autoCommit: Boolean): F[Unit]
   def commit: F[Unit]
+  def rollback: F[Unit]
   def close: F[Unit]
 }
 
@@ -29,6 +30,8 @@ object ConnectionWrapper {
     override def setAutoCommit(autoCommit: Boolean): Future[Unit] = Future(c.setAutoCommit(autoCommit))
 
     override def commit: Future[Unit] = Future(c.commit())
+
+    override def rollback: Future[Unit] = Future(c.rollback())
   }
 
   object Impl {

--- a/src/main/scala/org/galaxio/gatling/jdbc/db/JDBCClient.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/db/JDBCClient.scala
@@ -19,27 +19,47 @@ object JDBCClient {
         inCurlyBraces: Boolean,
         m: ParamToIndexesMap,
     )
-    private val emptyCtx = InterpolatorCtx("", "", 0, inCurlyBraces = false, Map.empty)
 
     private[this] def putToCtx(ctx: Map[String, List[Int]], name: String, number: Int): Map[String, List[Int]] = {
       val numbers = ctx.getOrElse(name, List.empty[Int])
       ctx ++ Map((name, number :: numbers))
     }
 
-    def interpolate(sql: String): InterpolatorCtx = sql.foldLeft(emptyCtx) {
-      case (ic @ InterpolatorCtx(_, _, _, false, _), '{')    => ic.copy(inCurlyBraces = true)
-      case (InterpolatorCtx(r, curName, n, true, ctx), '}')  =>
-        InterpolatorCtx(s"$r ?", "", n + 1, inCurlyBraces = false, putToCtx(ctx, curName, n + 1))
-      case (ic @ InterpolatorCtx(_, curName, _, true, _), c) => ic.copy(paramName = s"$curName$c")
+    def interpolate(sql: String): InterpolatorCtx = {
+      val queryBuilder = new StringBuilder(sql.length)
+      val nameBuilder  = new StringBuilder(16)
+      var paramIndex   = 0
+      var inBraces     = false
+      var paramMap     = Map.empty[String, List[Int]]
 
-      case (ic @ InterpolatorCtx(r, _, _, false, _), c) => ic.copy(queryString = s"$r$c")
+      sql.foreach {
+        case '{' if !inBraces =>
+          inBraces = true
+          nameBuilder.clear()
+        case '}' if inBraces  =>
+          paramIndex += 1
+          queryBuilder.append(" ?")
+          val name = nameBuilder.toString()
+          paramMap = putToCtx(paramMap, name, paramIndex)
+          inBraces = false
+        case c if inBraces    =>
+          nameBuilder.append(c)
+        case c                =>
+          queryBuilder.append(c)
+      }
+
+      InterpolatorCtx(queryBuilder.toString(), "", paramIndex, inCurlyBraces = false, paramMap)
     }
   }
 
-  def apply(pool: HikariDataSource, blockingPool: ExecutorService): JDBCClient = new JDBCClient(pool, blockingPool)
+  def apply(
+      pool: HikariDataSource,
+      blockingPool: ExecutorService,
+      queryTimeoutSeconds: Option[Int] = None,
+  ): JDBCClient = new JDBCClient(pool, blockingPool, queryTimeoutSeconds)
 }
 
-class JDBCClient(pool: HikariDataSource, blockingPool: ExecutorService) {
+class JDBCClient(pool: HikariDataSource, blockingPool: ExecutorService, queryTimeoutSeconds: Option[Int]) {
   private implicit val ec: ExecutionContext = ExecutionContext.fromExecutorService(blockingPool)
 
   private def connectionResource: ResourceFut[ConnectionWrapper[Future]] =
@@ -59,10 +79,29 @@ class JDBCClient(pool: HikariDataSource, blockingPool: ExecutorService) {
                     )
     } yield stmt
 
+  private def transactionResource: ResourceFut[(ConnectionWrapper[Future], StatementWrapper[Future])] =
+    for {
+      conn       <- connectionResource
+      autoCommit <- ResourceFut.liftFuture(conn.getAutoCommit)
+      _          <- ResourceFut.liftFuture(conn.setAutoCommit(false))
+      stmt       <- ResourceFut.make(conn.createStatement.map { s =>
+                      queryTimeoutSeconds.foreach(s.setQueryTimeout)
+                      statement(s, ec)
+                    })(s =>
+                      for {
+                        _ <- conn.setAutoCommit(autoCommit)
+                        _ <- s.close
+                      } yield (),
+                    )
+    } yield (conn, stmt)
+
   private def statementResource: ResourceFut[StatementWrapper[Future]] =
     for {
       conn <- connectionResource
-      stmt <- ResourceFut.make(conn.createStatement.map(statement(_, ec)))(_.close)
+      stmt <- ResourceFut.make(conn.createStatement.map { s =>
+                queryTimeoutSeconds.foreach(s.setQueryTimeout)
+                statement(s, ec)
+              })(_.close)
     } yield stmt
 
   private def preparedStatementResource(
@@ -75,7 +114,10 @@ class JDBCClient(pool: HikariDataSource, blockingPool: ExecutorService) {
       stmt            <- ResourceFut.make(
                            conn
                              .prepareStatement(interpolatedCtx.queryString)
-                             .map(preparedStatement(_, ec)),
+                             .map { ps =>
+                               queryTimeoutSeconds.foreach(ps.setQueryTimeout)
+                               preparedStatement(ps, ec)
+                             },
                          )(_.close)
       _               <- ResourceFut.liftFuture(stmt.setParams(interpolatedCtx, params))
     } yield stmt
@@ -90,8 +132,11 @@ class JDBCClient(pool: HikariDataSource, blockingPool: ExecutorService) {
       interpolatedCtx <- ResourceFut.liftFuture(Future(Interpolator.interpolate(sql)))
       stmt            <- ResourceFut.make(
                            conn
-                             .prepareCall(s"${interpolatedCtx.queryString}")
-                             .map(callableStatement(_, ec)),
+                             .prepareCall(interpolatedCtx.queryString)
+                             .map { cs =>
+                               queryTimeoutSeconds.foreach(cs.setQueryTimeout)
+                               callableStatement(cs, ec)
+                             },
                          )(_.close)
       _               <- ResourceFut.liftFuture(stmt.setParams(interpolatedCtx, inParams, outParams))
     } yield stmt
@@ -116,15 +161,31 @@ class JDBCClient(pool: HikariDataSource, blockingPool: ExecutorService) {
   ): Unit =
     withCompletion(callableStatementResource(sqlCall, params.toMap, outParams.toMap).use(_.executeUpdate))(s, f)
 
+  def executeTransaction[U](statements: Seq[String])(s: Int => U, f: Throwable => U): Unit =
+    if (statements.isEmpty) s(0)
+    else
+      withCompletion(transactionResource.use { case (conn, stmt) =>
+        statements
+          .foldLeft(Future.successful(0)) { (acc, sql) =>
+            acc.flatMap(count => stmt.execute(sql).map(_ => count + 1))
+          }
+          .flatMap(count => conn.commit.map(_ => count))
+          .recoverWith { case ex =>
+            conn.rollback.flatMap(_ => Future.failed(ex))
+          }
+      })(s, f)
+
   def batch[U](queries: Seq[SqlWithParam])(s: Array[Int] => U, f: Throwable => U): Unit =
-    withCompletion(
-      statementForBatchResource.use(stmt =>
-        queries
-          .map(query => stmt.addBatch(query.substituteParams))
-          .reduce((f1, f2) => f1.flatMap(_ => f2))
-          .flatMap(_ => stmt.executeBatch),
-      ),
-    )(s, f)
+    if (queries.isEmpty) s(Array.empty[Int])
+    else
+      withCompletion(
+        statementForBatchResource.use(stmt =>
+          queries
+            .map(query => stmt.addBatch(query.substituteParams))
+            .reduce((f1, f2) => f1.flatMap(_ => f2))
+            .flatMap(_ => stmt.executeBatch),
+        ),
+      )(s, f)
 
   def close(): Unit = {
     pool.close()

--- a/src/main/scala/org/galaxio/gatling/jdbc/db/package.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/db/package.scala
@@ -50,14 +50,24 @@ package object db {
       }
 
     def substituteParams: String = {
-      sql
-        .foldLeft(("", "", false)) {
-          case ((r, curName, false), '{') => (r, curName, true)
-          case ((r, curName, true), '}')  => (s"$r ${paramValueToSql(curName.trim)}", "", false)
-          case ((r, curName, true), c)    => (r, s"$curName$c", true)
-          case ((r, curName, false), c)   => (s"$r$c", curName, false)
-        }
-        ._1
+      val result   = new StringBuilder(sql.length)
+      val name     = new StringBuilder(16)
+      var inBraces = false
+
+      sql.foreach {
+        case '{' if !inBraces =>
+          inBraces = true
+          name.clear()
+        case '}' if inBraces  =>
+          result.append(' ').append(paramValueToSql(name.toString().trim))
+          inBraces = false
+        case c if inBraces    =>
+          name.append(c)
+        case c                =>
+          result.append(c)
+      }
+
+      result.toString()
     }
 
     def withOutParams(ps: Seq[(String, Int)]): SqlWithParam = SqlWithParam(sql, params, ps)

--- a/src/main/scala/org/galaxio/gatling/jdbc/protocol/JdbcComponents.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/protocol/JdbcComponents.scala
@@ -1,11 +1,28 @@
 package org.galaxio.gatling.jdbc.protocol
 
+import com.zaxxer.hikari.HikariDataSource
 import io.gatling.core.protocol.ProtocolComponents
 import io.gatling.core.session.Session
 import org.galaxio.gatling.jdbc.db.JDBCClient
+import org.slf4j.LoggerFactory
 
-case class JdbcComponents(client: JDBCClient) extends ProtocolComponents {
+case class JdbcComponents(client: JDBCClient, dataSource: HikariDataSource) extends ProtocolComponents {
+  private val logger = LoggerFactory.getLogger(classOf[JdbcComponents])
+
   override def onStart: Session => Session = Session.Identity
 
-  override def onExit: Session => Unit = _ => ()
+  override def onExit: Session => Unit = _ => {
+    logPoolMetrics()
+    client.close()
+  }
+
+  def logPoolMetrics(): Unit = {
+    val pool = dataSource.getHikariPoolMXBean
+    if (pool != null) {
+      logger.info(
+        s"HikariCP pool metrics — active: ${pool.getActiveConnections}, idle: ${pool.getIdleConnections}, " +
+          s"waiting: ${pool.getThreadsAwaitingConnection}, total: ${pool.getTotalConnections}",
+      )
+    }
+  }
 }

--- a/src/main/scala/org/galaxio/gatling/jdbc/protocol/JdbcProtocol.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/protocol/JdbcProtocol.scala
@@ -8,6 +8,7 @@ import org.galaxio.gatling.jdbc.db._
 
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.{Executors, ThreadFactory}
+import scala.concurrent.duration.FiniteDuration
 
 object JdbcProtocol {
   private final class JdbcThreadFactory(prefix: String) extends ThreadFactory {
@@ -32,12 +33,19 @@ object JdbcProtocol {
       protocol => {
         val blockingPool   = Executors.newFixedThreadPool(protocol.blockingPoolSize, new JdbcThreadFactory("jdbc-blocking"))
         val connectionPool = new HikariDataSource(protocol.hikariConfig)
-        JdbcComponents(JDBCClient(connectionPool, blockingPool))
+        JdbcComponents(
+          JDBCClient(connectionPool, blockingPool, protocol.queryTimeout.map(_.toSeconds.toInt)),
+          connectionPool,
+        )
       }
   }
 
 }
 
-case class JdbcProtocol(hikariConfig: HikariConfig, blockingPoolSize: Int) extends Protocol {
+case class JdbcProtocol(
+    hikariConfig: HikariConfig,
+    blockingPoolSize: Int,
+    queryTimeout: Option[FiniteDuration] = None,
+) extends Protocol {
   type Components = JdbcComponents
 }

--- a/src/main/scala/org/galaxio/gatling/jdbc/protocol/JdbcProtocolBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/protocol/JdbcProtocolBuilder.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration._
 case object JdbcProtocolBuilderBase {
 
   def url(url: String): JdbcProtocolBuilderUsernameStep    = JdbcProtocolBuilderUsernameStep(url)
-  def hikariConfig(cfg: HikariConfig): JdbcProtocolBuilder = JdbcProtocolBuilder(cfg, cfg.getMaximumPoolSize)
+  def hikariConfig(cfg: HikariConfig): JdbcProtocolBuilder = JdbcProtocolBuilder(cfg, cfg.getMaximumPoolSize, None)
 
 }
 
@@ -33,6 +33,7 @@ final case class JdbcProtocolBuilderConnectionSettingsStep(
     minimumIdleConnections: Int = 10,
     blockingPoolSize: Option[Int] = None,
     connectionTimeout: FiniteDuration = 1.minute,
+    queryTimeout: Option[FiniteDuration] = None,
 ) {
   def protocolBuilder: JdbcProtocolBuilder = {
     val hikariConfig = new HikariConfig()
@@ -44,7 +45,7 @@ final case class JdbcProtocolBuilderConnectionSettingsStep(
     hikariConfig.setMinimumIdle(minimumIdleConnections)
     hikariConfig.setConnectionTimeout(connectionTimeout.toMillis)
 
-    JdbcProtocolBuilder(hikariConfig, blockingPoolSize.getOrElse(maximumPoolSize))
+    JdbcProtocolBuilder(hikariConfig, blockingPoolSize.getOrElse(maximumPoolSize), queryTimeout)
   }
 
   def maximumPoolSize(newValue: Int): JdbcProtocolBuilderConnectionSettingsStep              =
@@ -55,10 +56,16 @@ final case class JdbcProtocolBuilderConnectionSettingsStep(
     this.copy(blockingPoolSize = Some(newValue))
   def connectionTimeout(newValue: FiniteDuration): JdbcProtocolBuilderConnectionSettingsStep =
     this.copy(connectionTimeout = newValue)
+  def queryTimeout(newValue: FiniteDuration): JdbcProtocolBuilderConnectionSettingsStep      =
+    this.copy(queryTimeout = Some(newValue))
 }
 
-final case class JdbcProtocolBuilder(hikariConfig: HikariConfig, blockingPoolSize: Int) {
+final case class JdbcProtocolBuilder(
+    hikariConfig: HikariConfig,
+    blockingPoolSize: Int,
+    queryTimeout: Option[FiniteDuration] = None,
+) {
 
-  def build: Protocol = JdbcProtocol(hikariConfig, blockingPoolSize)
+  def build: Protocol = JdbcProtocol(hikariConfig, blockingPoolSize, queryTimeout)
 
 }

--- a/src/test/scala/org/galaxio/gatling/jdbc/check/JdbcCheckSupportSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/check/JdbcCheckSupportSpec.scala
@@ -68,4 +68,58 @@ class JdbcCheckSupportSpec extends AnyFlatSpec with Matchers with JdbcCheckSuppo
       case other                  => fail(s"Expected a failed validation, got $other")
     }
   }
+
+  "allResults" should "save the full result set" in {
+    val (updatedSession, error) = runChecks(rows, allResults.saveAs("all"))
+
+    error shouldBe None
+    updatedSession.attributes("all") shouldBe rows
+  }
+
+  it should "handle empty result set" in {
+    val (updatedSession, error) = runChecks(List.empty, allResults.saveAs("all"))
+
+    error shouldBe None
+    updatedSession.attributes("all") shouldBe List.empty
+  }
+
+  "column" should "fail with a useful message when the column is missing" in {
+    val (_, error) = runChecks(rows, column("AGE").exists)
+
+    error match {
+      case Some(Failure(message)) =>
+        message should include("Column 'AGE' was not found")
+      case other                  => fail(s"Expected a failed validation, got $other")
+    }
+  }
+
+  it should "handle empty result set" in {
+    val (updatedSession, error) = runChecks(List.empty, column("NAME").saveAs("names"))
+
+    error shouldBe None
+    updatedSession.attributes("names") shouldBe List.empty
+  }
+
+  "cell" should "fail when row index is out of bounds" in {
+    val (_, error) = runChecks(rows, cell("NAME", 5).exists)
+
+    error match {
+      case Some(Failure(message)) =>
+        message should include("Row index 5 is out of bounds")
+      case other                  => fail(s"Expected a failed validation, got $other")
+    }
+  }
+
+  "simpleCheck" should "pass when predicate is true" in {
+    val (_, error) = runChecks(rows, simpleCheck(_.nonEmpty))
+    error shouldBe None
+  }
+
+  it should "fail when predicate is false" in {
+    val (_, error) = runChecks(rows, simpleCheck(_.isEmpty))
+    error match {
+      case Some(Failure(message)) => message should include("Jdbc check failed")
+      case other                  => fail(s"Expected failure, got $other")
+    }
+  }
 }

--- a/src/test/scala/org/galaxio/gatling/jdbc/db/InterpolatorSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/db/InterpolatorSpec.scala
@@ -1,0 +1,67 @@
+package org.galaxio.gatling.jdbc.db
+
+import org.galaxio.gatling.jdbc.db.JDBCClient.Interpolator
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class InterpolatorSpec extends AnyFlatSpec with Matchers {
+
+  "Interpolator" should "replace single param with ?" in {
+    val ctx = Interpolator.interpolate("SELECT * FROM t WHERE id = {id}")
+    ctx.queryString shouldBe "SELECT * FROM t WHERE id =  ?"
+    ctx.m should contain key "id"
+    ctx.m("id") shouldBe List(1)
+  }
+
+  it should "replace multiple params" in {
+    val ctx = Interpolator.interpolate("INSERT INTO t (a, b) VALUES ({a}, {b})")
+    ctx.queryString shouldBe "INSERT INTO t (a, b) VALUES ( ?,  ?)"
+    ctx.m should have size 2
+  }
+
+  it should "handle repeated params" in {
+    val ctx = Interpolator.interpolate("SELECT * FROM t WHERE a = {x} OR b = {x}")
+    ctx.m("x") should have size 2
+  }
+
+  it should "return original SQL when no params" in {
+    val ctx = Interpolator.interpolate("SELECT * FROM t")
+    ctx.queryString shouldBe "SELECT * FROM t"
+    ctx.m shouldBe empty
+  }
+
+  it should "handle empty string" in {
+    val ctx = Interpolator.interpolate("")
+    ctx.queryString shouldBe ""
+    ctx.m shouldBe empty
+  }
+
+  it should "handle special characters in SQL" in {
+    val ctx = Interpolator.interpolate("SELECT * FROM t WHERE name LIKE '%test%' AND id = {id}")
+    ctx.queryString should include("%test%")
+    ctx.m should contain key "id"
+  }
+
+  "SubstituteParams" should "replace params with literal values" in {
+    val sql    = SqlWithParam(
+      "INSERT INTO t (name, age) VALUES ({name}, {age})",
+      Seq("name" -> StrParam("Alice"), "age" -> IntParam(30)),
+    )
+    val result = sql.substituteParams
+    result should include("'Alice'")
+    result should include("30")
+  }
+
+  it should "handle NULL values" in {
+    val sql = SqlWithParam(
+      "INSERT INTO t (name) VALUES ({name})",
+      Seq("name" -> NullParam),
+    )
+    sql.substituteParams should include("NULL")
+  }
+
+  it should "handle empty params" in {
+    val sql = SqlWithParam("SELECT 1", Seq.empty)
+    sql.substituteParams shouldBe "SELECT 1"
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/jdbc/integration/MysqlIntegrationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/integration/MysqlIntegrationSpec.scala
@@ -1,0 +1,159 @@
+package org.galaxio.gatling.jdbc.integration
+
+import com.dimafeng.testcontainers.{ForAllTestContainer, MySQLContainer}
+import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
+import org.galaxio.gatling.jdbc.db._
+import org.galaxio.gatling.jdbc.tags.DockerTest
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.testcontainers.utility.DockerImageName
+
+import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
+
+class MysqlIntegrationSpec extends AnyWordSpec with Matchers with ForAllTestContainer with BeforeAndAfterAll {
+
+  override val container: MySQLContainer = MySQLContainer(
+    mysqlImageVersion = DockerImageName.parse("mysql:8.0"),
+  )
+
+  private lazy val ds = {
+    val cfg = new HikariConfig()
+    cfg.setJdbcUrl(container.jdbcUrl)
+    cfg.setUsername(container.username)
+    cfg.setPassword(container.password)
+    cfg.setMaximumPoolSize(4)
+    new HikariDataSource(cfg)
+  }
+
+  private lazy val client = JDBCClient(ds, Executors.newFixedThreadPool(4))
+
+  private def await[T](action: ((T => Unit, Throwable => Unit) => Unit)): T = {
+    val latch                        = new CountDownLatch(1)
+    var result: Either[Throwable, T] = Left(new RuntimeException("timeout"))
+    action(
+      v => { result = Right(v); latch.countDown() },
+      e => { result = Left(e); latch.countDown() },
+    )
+    latch.await(30, TimeUnit.SECONDS)
+    result.fold(throw _, identity)
+  }
+
+  "MySQL integration" should {
+    "execute DDL and CRUD" taggedAs DockerTest in {
+      await[Boolean](
+        client.executeRaw(
+          "CREATE TABLE IF NOT EXISTS test_mysql (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), score DOUBLE)",
+        ),
+      )
+
+      await[Boolean](client.executeRaw("INSERT INTO test_mysql (name, score) VALUES ('Alice', 95.5)"))
+      await[Boolean](client.executeRaw("INSERT INTO test_mysql (name, score) VALUES ('Bob', 87.3)"))
+
+      val rows = await[List[Map[String, Any]]](
+        client.executeSelect("SELECT name, score FROM test_mysql ORDER BY name", Seq.empty),
+      )
+
+      rows should have size 2
+      rows.head("name") shouldBe "Alice"
+      rows.head("score") shouldBe 95.5
+    }
+
+    "execute parameterized queries" taggedAs DockerTest in {
+      val rows = await[List[Map[String, Any]]](
+        client.executeSelect(
+          "SELECT name FROM test_mysql WHERE score > {minScore}",
+          Seq("minScore" -> DoubleParam(90.0)),
+        ),
+      )
+
+      rows should have size 1
+      rows.head("name") shouldBe "Alice"
+    }
+
+    "execute batch operations" taggedAs DockerTest in {
+      await[Boolean](
+        client.executeRaw(
+          "CREATE TABLE IF NOT EXISTS batch_mysql (id INT AUTO_INCREMENT PRIMARY KEY, val VARCHAR(255))",
+        ),
+      )
+
+      val queries = (1 to 3).map { i =>
+        SQL(s"INSERT INTO batch_mysql (val) VALUES ('item-$i')").withParams()
+      }
+
+      val results = await[Array[Int]](client.batch(queries))
+      results.length shouldBe 3
+    }
+
+    "execute update with params" taggedAs DockerTest in {
+      val updated = await[Int](
+        client.executeUpdate(
+          "UPDATE test_mysql SET score = {score} WHERE name = {name}",
+          Seq("score" -> DoubleParam(99.9), "name" -> StrParam("Alice")),
+        ),
+      )
+      updated shouldBe 1
+    }
+
+    "execute transaction with commit" taggedAs DockerTest in {
+      await[Boolean](
+        client.executeRaw("CREATE TABLE IF NOT EXISTS tx_mysql (id INT AUTO_INCREMENT PRIMARY KEY, val VARCHAR(255))"),
+      )
+
+      val count = await[Int](
+        client.executeTransaction(
+          Seq(
+            "INSERT INTO tx_mysql (val) VALUES ('tx1')",
+            "INSERT INTO tx_mysql (val) VALUES ('tx2')",
+          ),
+        ),
+      )
+      count shouldBe 2
+
+      val rows = await[List[Map[String, Any]]](
+        client.executeSelect("SELECT COUNT(*) AS cnt FROM tx_mysql", Seq.empty),
+      )
+      rows.head("cnt").asInstanceOf[Long] shouldBe 2L
+    }
+
+    "rollback transaction on error" taggedAs DockerTest in {
+      await[Boolean](
+        client.executeRaw(
+          "CREATE TABLE IF NOT EXISTS tx_rollback_mysql (id INT AUTO_INCREMENT PRIMARY KEY, val VARCHAR(255) NOT NULL)",
+        ),
+      )
+
+      an[Exception] shouldBe thrownBy {
+        await[Int](
+          client.executeTransaction(
+            Seq(
+              "INSERT INTO tx_rollback_mysql (val) VALUES ('ok')",
+              "INSERT INTO tx_rollback_mysql (val) VALUES (NULL)",
+            ),
+          ),
+        )
+      }
+
+      val rows = await[List[Map[String, Any]]](
+        client.executeSelect("SELECT COUNT(*) AS cnt FROM tx_rollback_mysql", Seq.empty),
+      )
+      rows.head("cnt").asInstanceOf[Long] shouldBe 0L
+    }
+
+    "handle NULL values" taggedAs DockerTest in {
+      await[Boolean](client.executeRaw("INSERT INTO test_mysql (name, score) VALUES (NULL, NULL)"))
+
+      val rows = await[List[Map[String, Any]]](
+        client.executeSelect("SELECT name, score FROM test_mysql WHERE name IS NULL", Seq.empty),
+      )
+      rows should have size 1
+      Option(rows.head("name")) shouldBe None
+    }
+  }
+
+  override def afterAll(): Unit = {
+    client.close()
+    super.afterAll()
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/jdbc/integration/PostgresIntegrationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/integration/PostgresIntegrationSpec.scala
@@ -1,0 +1,196 @@
+package org.galaxio.gatling.jdbc.integration
+
+import com.dimafeng.testcontainers.{ForAllTestContainer, PostgreSQLContainer}
+import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
+import org.galaxio.gatling.jdbc.db._
+import org.galaxio.gatling.jdbc.tags.DockerTest
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.testcontainers.utility.DockerImageName
+
+import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
+
+class PostgresIntegrationSpec extends AnyWordSpec with Matchers with ForAllTestContainer with BeforeAndAfterAll {
+
+  override val container: PostgreSQLContainer = PostgreSQLContainer(
+    dockerImageNameOverride = DockerImageName.parse("postgres:16-alpine"),
+  )
+
+  private lazy val ds = {
+    val cfg = new HikariConfig()
+    cfg.setJdbcUrl(container.jdbcUrl)
+    cfg.setUsername(container.username)
+    cfg.setPassword(container.password)
+    cfg.setMaximumPoolSize(4)
+    new HikariDataSource(cfg)
+  }
+
+  private lazy val client = JDBCClient(ds, Executors.newFixedThreadPool(4))
+
+  private def await[T](action: ((T => Unit, Throwable => Unit) => Unit)): T = {
+    val latch                        = new CountDownLatch(1)
+    var result: Either[Throwable, T] = Left(new RuntimeException("timeout"))
+    action(
+      v => { result = Right(v); latch.countDown() },
+      e => { result = Left(e); latch.countDown() },
+    )
+    latch.await(30, TimeUnit.SECONDS)
+    result.fold(throw _, identity)
+  }
+
+  "PostgreSQL integration" should {
+    "execute DDL via raw SQL" taggedAs DockerTest in {
+      val ok = await[Boolean](
+        client.executeRaw("CREATE TABLE IF NOT EXISTS test_pg (id SERIAL PRIMARY KEY, name TEXT, active BOOLEAN)"),
+      )
+      ok shouldBe false // DDL returns false for execute()
+    }
+
+    "insert and select data" taggedAs DockerTest in {
+      await[Boolean](client.executeRaw("INSERT INTO test_pg (name, active) VALUES ('Alice', true)"))
+      await[Boolean](client.executeRaw("INSERT INTO test_pg (name, active) VALUES ('Bob', false)"))
+
+      val rows = await[List[Map[String, Any]]](
+        client.executeSelect("SELECT name, active FROM test_pg ORDER BY name", Seq.empty),
+      )
+
+      rows should have size 2
+      rows.head("name") shouldBe "Alice"
+      rows.head("active") shouldBe true
+      rows(1)("name") shouldBe "Bob"
+      rows(1)("active") shouldBe false
+    }
+
+    "execute parameterized queries" taggedAs DockerTest in {
+      val rows = await[List[Map[String, Any]]](
+        client.executeSelect(
+          "SELECT name FROM test_pg WHERE active = {active}",
+          Seq("active" -> BooleanParam(true)),
+        ),
+      )
+
+      rows should have size 1
+      rows.head("name") shouldBe "Alice"
+    }
+
+    "execute update with params" taggedAs DockerTest in {
+      val updated = await[Int](
+        client.executeUpdate(
+          "UPDATE test_pg SET name = {name} WHERE name = {old}",
+          Seq("name" -> StrParam("Charlie"), "old" -> StrParam("Bob")),
+        ),
+      )
+      updated shouldBe 1
+
+      val rows = await[List[Map[String, Any]]](
+        client.executeSelect("SELECT name FROM test_pg WHERE name = {n}", Seq("n" -> StrParam("Charlie"))),
+      )
+      rows should have size 1
+    }
+
+    "handle NULL values" taggedAs DockerTest in {
+      await[Boolean](client.executeRaw("INSERT INTO test_pg (name, active) VALUES (NULL, NULL)"))
+
+      val rows = await[List[Map[String, Any]]](
+        client.executeSelect("SELECT name, active FROM test_pg WHERE name IS NULL", Seq.empty),
+      )
+      rows should have size 1
+      Option(rows.head("name")) shouldBe None
+      Option(rows.head("active")) shouldBe None
+    }
+
+    "execute batch operations" taggedAs DockerTest in {
+      await[Boolean](client.executeRaw("CREATE TABLE IF NOT EXISTS batch_pg (id SERIAL PRIMARY KEY, val TEXT)"))
+
+      val queries = (1 to 5).map { i =>
+        SQL(s"INSERT INTO batch_pg (val) VALUES ('item-$i')").withParams()
+      }
+
+      val results = await[Array[Int]](client.batch(queries))
+      results.length shouldBe 5
+
+      val rows = await[List[Map[String, Any]]](
+        client.executeSelect("SELECT COUNT(*) AS cnt FROM batch_pg", Seq.empty),
+      )
+      rows.head("cnt").asInstanceOf[Long] shouldBe 5L
+    }
+
+    "execute transaction with commit" taggedAs DockerTest in {
+      await[Boolean](
+        client.executeRaw("CREATE TABLE IF NOT EXISTS tx_pg (id SERIAL PRIMARY KEY, val TEXT)"),
+      )
+
+      val count = await[Int](
+        client.executeTransaction(
+          Seq(
+            "INSERT INTO tx_pg (val) VALUES ('tx1')",
+            "INSERT INTO tx_pg (val) VALUES ('tx2')",
+            "INSERT INTO tx_pg (val) VALUES ('tx3')",
+          ),
+        ),
+      )
+      count shouldBe 3
+
+      val rows = await[List[Map[String, Any]]](
+        client.executeSelect("SELECT COUNT(*) AS cnt FROM tx_pg", Seq.empty),
+      )
+      rows.head("cnt").asInstanceOf[Long] shouldBe 3L
+    }
+
+    "rollback transaction on error" taggedAs DockerTest in {
+      await[Boolean](
+        client.executeRaw("CREATE TABLE IF NOT EXISTS tx_rollback_pg (id SERIAL PRIMARY KEY, val TEXT NOT NULL)"),
+      )
+
+      an[Exception] shouldBe thrownBy {
+        await[Int](
+          client.executeTransaction(
+            Seq(
+              "INSERT INTO tx_rollback_pg (val) VALUES ('ok')",
+              "INSERT INTO tx_rollback_pg (val) VALUES (NULL)",
+            ),
+          ),
+        )
+      }
+
+      val rows = await[List[Map[String, Any]]](
+        client.executeSelect("SELECT COUNT(*) AS cnt FROM tx_rollback_pg", Seq.empty),
+      )
+      rows.head("cnt").asInstanceOf[Long] shouldBe 0L
+    }
+
+    "handle empty transaction" taggedAs DockerTest in {
+      val count = await[Int](client.executeTransaction(Seq.empty))
+      count shouldBe 0
+    }
+
+    "handle empty batch" taggedAs DockerTest in {
+      val results = await[Array[Int]](client.batch(Seq.empty))
+      results shouldBe empty
+    }
+
+    "execute callable statement (function)" taggedAs DockerTest in {
+      await[Boolean](
+        client.executeRaw(
+          """CREATE OR REPLACE FUNCTION add_one(x INT) RETURNS INT AS $$
+          |BEGIN RETURN x + 1; END;
+          |$$ LANGUAGE plpgsql""".stripMargin,
+        ),
+      )
+
+      await[Boolean](client.executeRaw("CREATE TABLE IF NOT EXISTS func_result_pg (result INT)"))
+      await[Boolean](client.executeRaw("INSERT INTO func_result_pg (result) SELECT add_one(41)"))
+
+      val rows = await[List[Map[String, Any]]](
+        client.executeSelect("SELECT result FROM func_result_pg", Seq.empty),
+      )
+      rows.head("result") shouldBe 42
+    }
+  }
+
+  override def afterAll(): Unit = {
+    client.close()
+    super.afterAll()
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/jdbc/protocol/JdbcProtocolBuilderSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/protocol/JdbcProtocolBuilderSpec.scala
@@ -34,4 +34,59 @@ class JdbcProtocolBuilderSpec extends AnyFlatSpec with Matchers {
 
     protocol.blockingPoolSize shouldBe 5
   }
+
+  it should "default queryTimeout to None" in {
+    val builder = JdbcProtocolBuilderConnectionSettingsStep(
+      url = "jdbc:h2:mem:test",
+      username = "sa",
+      password = "",
+    )
+
+    val protocol = builder.protocolBuilder.build.asInstanceOf[JdbcProtocol]
+
+    protocol.queryTimeout shouldBe None
+  }
+
+  it should "allow setting queryTimeout" in {
+    val builder = JdbcProtocolBuilderConnectionSettingsStep(
+      url = "jdbc:h2:mem:test",
+      username = "sa",
+      password = "",
+    ).queryTimeout(10.seconds)
+
+    val protocol = builder.protocolBuilder.build.asInstanceOf[JdbcProtocol]
+
+    protocol.queryTimeout shouldBe Some(10.seconds)
+  }
+
+  "JdbcProtocolBuilderBase" should "build from HikariConfig" in {
+    val cfg = new com.zaxxer.hikari.HikariConfig()
+    cfg.setJdbcUrl("jdbc:h2:mem:test")
+    cfg.setMaximumPoolSize(8)
+
+    val protocol = JdbcProtocolBuilderBase.hikariConfig(cfg).build.asInstanceOf[JdbcProtocol]
+
+    protocol.blockingPoolSize shouldBe 8
+    protocol.queryTimeout shouldBe None
+  }
+
+  "Builder step chain" should "support fluent API" in {
+    val step = JdbcProtocolBuilderBase
+      .url("jdbc:h2:mem:test")
+      .username("sa")
+      .password("")
+      .maximumPoolSize(16)
+      .minimumIdleConnections(4)
+      .blockingPoolSize(8)
+      .connectionTimeout(45.seconds)
+      .queryTimeout(5.seconds)
+
+    val protocol = step.protocolBuilder.build.asInstanceOf[JdbcProtocol]
+
+    protocol.blockingPoolSize shouldBe 8
+    protocol.queryTimeout shouldBe Some(5.seconds)
+    protocol.hikariConfig.getMaximumPoolSize shouldBe 16
+    protocol.hikariConfig.getMinimumIdle shouldBe 4
+    protocol.hikariConfig.getConnectionTimeout shouldBe 45000L
+  }
 }

--- a/src/test/scala/org/galaxio/gatling/jdbc/tags/DockerTest.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/tags/DockerTest.scala
@@ -1,0 +1,5 @@
+package org.galaxio.gatling.jdbc.tags
+
+import org.scalatest.Tag
+
+object DockerTest extends Tag("org.galaxio.gatling.jdbc.tags.DockerTest")


### PR DESCRIPTION
## Summary

- **Bug fixes**: SQL interpolator O(n²)→StringBuilder, empty batch guard, filename typo (JdbcProtocolBuider→Builder)
- **Transaction support**: `jdbc("tx").transaction(sql1, sql2, ...)` with commit/rollback semantics, Java/Kotlin API wrappers
- **Query timeout**: configurable via `queryTimeout()` builder method
- **HikariCP pool metrics**: logged on protocol stop (active/idle/waiting/total connections)
- **Integration tests**: PostgreSQL + MySQL testcontainer specs, InterpolatorSpec, expanded check/builder specs (37 total, up from 17)
- **CI overhaul**: 3 parallel jobs (format, test matrix 17+21, integration with Docker), auto-tag on main merge via conventional commits, upgraded actions
- **README**: fixed badges, Maven/Gradle install tabs, documented transactions, query timeout, pool metrics

## Test plan

- [ ] `sbt test` — 37 unit tests pass (Docker tests excluded)
- [ ] `sbt "Test / testOnly -- -n org.galaxio.gatling.jdbc.tags.DockerTest"` — PostgreSQL + MySQL integration (needs Docker)
- [ ] `sbt scalafmtCheckAll` — formatting clean
- [ ] `sbt "Gatling / testOnly *JdbcSimulation"` — Gatling H2 simulation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)