### PR TITLE
feat: add unit regression tests for ResourceFut, SQL mapping, and action failure

### DIFF
--- a/src/test/scala/org/galaxio/gatling/jdbc/db/ResourceFutSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/db/ResourceFutSpec.scala
@@ -40,14 +40,16 @@ class ResourceFutSpec extends AnyFlatSpec with Matchers {
 
   it should "call release exactly once after a successful use" in {
     val releaseCount = new AtomicInteger(0)
-    val resource     = ResourceFut.make(Future.successful("res"))(_ => Future.successful(releaseCount.incrementAndGet()).map(_ => ()))
+    val resource     =
+      ResourceFut.make(Future.successful("res"))(_ => Future.successful(releaseCount.incrementAndGet()).map(_ => ()))
     await(resource.use(_ => Future.successful(42)))
     releaseCount.get() shouldBe 1
   }
 
   it should "call release exactly once when the use-function fails" in {
     val releaseCount = new AtomicInteger(0)
-    val resource     = ResourceFut.make(Future.successful("res"))(_ => Future.successful(releaseCount.incrementAndGet()).map(_ => ()))
+    val resource     =
+      ResourceFut.make(Future.successful("res"))(_ => Future.successful(releaseCount.incrementAndGet()).map(_ => ()))
     awaitFailed(resource.use(_ => Future.failed(new RuntimeException("op failed"))))
     releaseCount.get() shouldBe 1
   }
@@ -167,17 +169,17 @@ class ResourceFutSpec extends AnyFlatSpec with Matchers {
 
   "ResourceFut.flatMap" should "chain two resources and make the inner value available to use" in {
     import ResourceFut.ResourceFutOps
-    val outer = ResourceFut.pure("hello")
-    val inner = outer.flatMap(s => ResourceFut.pure(s.length))
+    val outer  = ResourceFut.pure("hello")
+    val inner  = outer.flatMap(s => ResourceFut.pure(s.length))
     val result = await(inner.use(n => Future.successful(n)))
     result shouldBe 5
   }
 
   it should "propagate a failure from the inner resource factory" in {
     import ResourceFut.ResourceFutOps
-    val ex    = new RuntimeException("inner resource failed")
-    val outer = ResourceFut.pure("hello")
-    val inner = outer.flatMap(_ => ResourceFut.liftFuture(Future.failed[Int](ex)))
+    val ex     = new RuntimeException("inner resource failed")
+    val outer  = ResourceFut.pure("hello")
+    val inner  = outer.flatMap(_ => ResourceFut.liftFuture(Future.failed[Int](ex)))
     val thrown = awaitFailed(inner.use(n => Future.successful(n)))
     thrown shouldBe ex
   }

--- a/src/test/scala/org/galaxio/gatling/jdbc/db/ResourceFutSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/db/ResourceFutSpec.scala
@@ -3,9 +3,24 @@ package org.galaxio.gatling.jdbc.db
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, ExecutionContext, Future}
 
+/** Unit-level regression tests for the ResourceFut resource-lifecycle abstraction.
+  *
+  * Covers:
+  *   - Happy-path acquire → use → release
+  *   - Acquire failure (resource never handed to the user, release not called)
+  *   - Operation failure with successful release (primary exception propagated, no suppressed)
+  *   - Operation failure with release failure (primary propagated, release added as suppressed)
+  *   - Release failure when operation succeeds (release exception propagated)
+  *   - Release is always called exactly once, even on failure
+  *   - ResourceFut.pure and ResourceFut.liftFuture smart constructors
+  *   - map and flatMap combinators
+  *
+  * All tests are in-memory and require no external services.
+  */
 class ResourceFutSpec extends AnyFlatSpec with Matchers {
 
   implicit val ec: ExecutionContext = ExecutionContext.global
@@ -15,7 +30,31 @@ class ResourceFutSpec extends AnyFlatSpec with Matchers {
   private def awaitFailed[A](f: Future[A]): Throwable =
     Await.ready(f, 5.seconds).value.get.failed.get
 
-  "ResourceFut.make" should "propagate the operation exception when release succeeds" in {
+  // ─── ResourceFut.make happy path ─────────────────────────────────────────────
+
+  "ResourceFut.make" should "return the result of the use-function on success" in {
+    val resource = ResourceFut.make(Future.successful("res"))(_ => Future.successful(()))
+    val result   = await(resource.use(r => Future.successful(r.length)))
+    result shouldBe 3
+  }
+
+  it should "call release exactly once after a successful use" in {
+    val releaseCount = new AtomicInteger(0)
+    val resource     = ResourceFut.make(Future.successful("res"))(_ => Future.successful(releaseCount.incrementAndGet()).map(_ => ()))
+    await(resource.use(_ => Future.successful(42)))
+    releaseCount.get() shouldBe 1
+  }
+
+  it should "call release exactly once when the use-function fails" in {
+    val releaseCount = new AtomicInteger(0)
+    val resource     = ResourceFut.make(Future.successful("res"))(_ => Future.successful(releaseCount.incrementAndGet()).map(_ => ()))
+    awaitFailed(resource.use(_ => Future.failed(new RuntimeException("op failed"))))
+    releaseCount.get() shouldBe 1
+  }
+
+  // ─── failure semantics ───────────────────────────────────────────────────────
+
+  it should "propagate the operation exception when release succeeds" in {
     val opException = new RuntimeException("op failed")
     val resource    = ResourceFut.make(Future.successful("res"))(_ => Future.successful(()))
     val result      = resource.use(_ => Future.failed(opException))
@@ -37,6 +76,17 @@ class ResourceFutSpec extends AnyFlatSpec with Matchers {
     thrown.getSuppressed.head shouldBe releaseException
   }
 
+  it should "not add the release exception as suppressed when it is the same object as the op exception" in {
+    val singleException = new RuntimeException("same exception")
+    val resource        = ResourceFut.make(Future.successful("res"))(_ => Future.failed(singleException))
+    val result          = resource.use(_ => Future.failed(singleException))
+
+    val thrown = awaitFailed(result)
+    thrown shouldBe singleException
+    // release exception is the same object — must NOT be added as suppressed (guarded by `ne` check)
+    thrown.getSuppressed.length shouldBe 0
+  }
+
   it should "propagate the release exception when operation succeeds but release fails" in {
     val releaseException = new RuntimeException("release failed")
     val resource         = ResourceFut.make(Future.successful("res"))(_ => Future.failed(releaseException))
@@ -44,5 +94,91 @@ class ResourceFutSpec extends AnyFlatSpec with Matchers {
 
     val thrown = awaitFailed(result)
     thrown shouldBe releaseException
+  }
+
+  it should "fail with the acquire exception and not call release when acquire fails" in {
+    val acquireException = new RuntimeException("acquire failed")
+    val releaseCount     = new AtomicInteger(0)
+    val resource         = ResourceFut.make(Future.failed[String](acquireException))(_ =>
+      Future.successful(releaseCount.incrementAndGet()).map(_ => ()),
+    )
+    val result           = resource.use(_ => Future.successful("should not run"))
+
+    val thrown = awaitFailed(result)
+    thrown shouldBe acquireException
+    releaseCount.get() shouldBe 0
+  }
+
+  // ─── ResourceFut.pure ────────────────────────────────────────────────────────
+
+  "ResourceFut.pure" should "wrap a value and make it available to the use-function" in {
+    val resource = ResourceFut.pure("value")
+    val result   = await(resource.use(v => Future.successful(v.toUpperCase)))
+    result shouldBe "VALUE"
+  }
+
+  it should "propagate a use-function failure without masking it" in {
+    val ex       = new RuntimeException("pure-use failed")
+    val resource = ResourceFut.pure("value")
+    val thrown   = awaitFailed(resource.use(_ => Future.failed(ex)))
+    thrown shouldBe ex
+  }
+
+  // ─── ResourceFut.liftFuture ──────────────────────────────────────────────────
+
+  "ResourceFut.liftFuture" should "make the future's value available to the use-function" in {
+    val resource = ResourceFut.liftFuture(Future.successful(99))
+    val result   = await(resource.use(n => Future.successful(n * 2)))
+    result shouldBe 198
+  }
+
+  it should "propagate a failure from the lifted future" in {
+    val ex       = new RuntimeException("lifted future failed")
+    val resource = ResourceFut.liftFuture(Future.failed[Int](ex))
+    val thrown   = awaitFailed(resource.use(n => Future.successful(n * 2)))
+    thrown shouldBe ex
+  }
+
+  it should "propagate a use-function failure" in {
+    val ex       = new RuntimeException("use failed after lift")
+    val resource = ResourceFut.liftFuture(Future.successful(1))
+    val thrown   = awaitFailed(resource.use(_ => Future.failed(ex)))
+    thrown shouldBe ex
+  }
+
+  // ─── map combinator ──────────────────────────────────────────────────────────
+
+  "ResourceFut.map" should "transform the resource value before handing it to use" in {
+    import ResourceFut.ResourceFutOps
+    val resource = ResourceFut.pure(10).map(_ * 3)
+    val result   = await(resource.use(n => Future.successful(n)))
+    result shouldBe 30
+  }
+
+  it should "propagate a use-function failure through the mapped resource" in {
+    import ResourceFut.ResourceFutOps
+    val ex       = new RuntimeException("map-use failed")
+    val resource = ResourceFut.pure("hello").map(_.length)
+    val thrown   = awaitFailed(resource.use(_ => Future.failed(ex)))
+    thrown shouldBe ex
+  }
+
+  // ─── flatMap combinator ──────────────────────────────────────────────────────
+
+  "ResourceFut.flatMap" should "chain two resources and make the inner value available to use" in {
+    import ResourceFut.ResourceFutOps
+    val outer = ResourceFut.pure("hello")
+    val inner = outer.flatMap(s => ResourceFut.pure(s.length))
+    val result = await(inner.use(n => Future.successful(n)))
+    result shouldBe 5
+  }
+
+  it should "propagate a failure from the inner resource factory" in {
+    import ResourceFut.ResourceFutOps
+    val ex    = new RuntimeException("inner resource failed")
+    val outer = ResourceFut.pure("hello")
+    val inner = outer.flatMap(_ => ResourceFut.liftFuture(Future.failed[Int](ex)))
+    val thrown = awaitFailed(inner.use(n => Future.successful(n)))
+    thrown shouldBe ex
   }
 }

--- a/src/test/scala/org/galaxio/gatling/jdbc/db/SqlWithParamSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/db/SqlWithParamSpec.scala
@@ -1,0 +1,173 @@
+package org.galaxio.gatling.jdbc.db
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+/** Unit-level regression tests for SQL interpolation and parameter mapping.
+  *
+  * Covers `SQL.withParamsMap` type-coercion logic and `SqlWithParam.substituteParams`
+  * string-rendering for every `ParamVal` variant.  These tests require no database — all
+  * assertions are over pure in-memory data structures.
+  *
+  * Protects against regressions in:
+  *   - type-dispatch in `withParamsMap` (wrong ParamVal produced for a Scala type)
+  *   - SQL-rendering in `paramValueToSql` (wrong SQL fragment for a ParamVal variant)
+  *   - placeholder parsing in `substituteParams` (brace delimiters, whitespace trimming)
+  */
+class SqlWithParamSpec extends AnyFlatSpec with Matchers {
+
+  // ─── withParamsMap type-coercion ─────────────────────────────────────────────
+
+  "SQL.withParamsMap" should "map Int values to IntParam" in {
+    val swp = SQL("SELECT {n}").withParamsMap(Map("n" -> 42))
+    swp.params should contain("n" -> IntParam(42))
+  }
+
+  it should "map Long values to LongParam" in {
+    val swp = SQL("SELECT {n}").withParamsMap(Map("n" -> 42L))
+    swp.params should contain("n" -> LongParam(42L))
+  }
+
+  it should "map Double values to DoubleParam" in {
+    val swp = SQL("SELECT {n}").withParamsMap(Map("n" -> 3.14))
+    swp.params should contain("n" -> DoubleParam(3.14))
+  }
+
+  it should "map Boolean values to BooleanParam" in {
+    val swp = SQL("SELECT {flag}").withParamsMap(Map("flag" -> true))
+    swp.params should contain("flag" -> BooleanParam(true))
+  }
+
+  it should "map String values to StrParam" in {
+    val swp = SQL("SELECT {s}").withParamsMap(Map("s" -> "hello"))
+    swp.params should contain("s" -> StrParam("hello"))
+  }
+
+  it should "map LocalDateTime values to DateParam" in {
+    val dt  = LocalDateTime.of(2024, 1, 15, 10, 30, 0)
+    val swp = SQL("SELECT {d}").withParamsMap(Map("d" -> dt))
+    swp.params should contain("d" -> DateParam(dt))
+  }
+
+  it should "map UUID values to UUIDParam" in {
+    val id  = UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
+    val swp = SQL("SELECT {id}").withParamsMap(Map("id" -> id))
+    swp.params should contain("id" -> UUIDParam(id))
+  }
+
+  it should "map null to NullParam" in {
+    val swp = SQL("SELECT {x}").withParamsMap(Map("x" -> null))
+    swp.params should contain("x" -> NullParam)
+  }
+
+  it should "map the sentinel string 'NULL' to NullParam" in {
+    val swp = SQL("SELECT {x}").withParamsMap(Map("x" -> "NULL"))
+    swp.params should contain("x" -> NullParam)
+  }
+
+  it should "fall back to StrParam(toString) for unknown types" in {
+    case class Custom(v: Int) { override def toString: String = s"custom-$v" }
+    val swp = SQL("SELECT {x}").withParamsMap(Map("x" -> Custom(7)))
+    swp.params should contain("x" -> StrParam("custom-7"))
+  }
+
+  it should "handle multiple parameters of mixed types in one call" in {
+    val swp = SQL("INSERT INTO t (a,b,c) VALUES ({a},{b},{c})")
+      .withParamsMap(Map("a" -> 1, "b" -> "two", "c" -> true))
+    swp.params.toMap should contain allOf (
+      "a" -> IntParam(1),
+      "b" -> StrParam("two"),
+      "c" -> BooleanParam(true),
+    )
+  }
+
+  // ─── substituteParams SQL rendering ──────────────────────────────────────────
+
+  "SqlWithParam.substituteParams" should "render IntParam as a bare integer literal" in {
+    val result = SQL("SELECT {n}").withParamsMap(Map("n" -> 42)).substituteParams
+    result.trim shouldBe "SELECT  42"
+  }
+
+  it should "render LongParam as a bare long literal" in {
+    val result = SQL("SELECT {n}").withParamsMap(Map("n" -> 100L)).substituteParams
+    result.trim shouldBe "SELECT  100"
+  }
+
+  it should "render DoubleParam as a bare double literal" in {
+    val result = SQL("WHERE v > {v}").withParamsMap(Map("v" -> 1.5)).substituteParams
+    result.trim shouldBe "WHERE v >  1.5"
+  }
+
+  it should "render StrParam wrapped in single quotes" in {
+    val result = SQL("WHERE name = {name}").withParamsMap(Map("name" -> "alice")).substituteParams
+    result.trim shouldBe "WHERE name =  'alice'"
+  }
+
+  it should "render NullParam as the keyword NULL" in {
+    val result = SQL("WHERE x = {x}").withParamsMap(Map("x" -> null)).substituteParams
+    result.trim shouldBe "WHERE x =  NULL"
+  }
+
+  it should "render BooleanParam as a bare boolean literal" in {
+    val resultTrue  = SQL("{f}").withParamsMap(Map("f" -> true)).substituteParams.trim
+    val resultFalse = SQL("{f}").withParamsMap(Map("f" -> false)).substituteParams.trim
+    resultTrue  shouldBe "true"
+    resultFalse shouldBe "false"
+  }
+
+  it should "render DateParam as a CAST TIMESTAMP expression" in {
+    val dt     = LocalDateTime.of(2024, 6, 1, 12, 0, 0)
+    val result = SQL("WHERE ts = {ts}").withParamsMap(Map("ts" -> dt)).substituteParams
+    result should include("CAST(")
+    result should include("AS TIMESTAMP)")
+    result should include("2024-06-01")
+  }
+
+  it should "render UUIDParam as a CAST UUID expression" in {
+    val id     = UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
+    val result = SQL("WHERE id = {id}").withParamsMap(Map("id" -> id)).substituteParams
+    result should include("CAST(")
+    result should include("AS UUID)")
+    result should include(id.toString)
+  }
+
+  it should "render an empty string for an unknown placeholder name" in {
+    // A placeholder that has no matching param key renders as an empty string fragment
+    val sql    = SqlWithParam("SELECT {missing}", params = Seq.empty)
+    val result = sql.substituteParams
+    result should not include "{missing}"
+  }
+
+  it should "substitute multiple placeholders in a single query" in {
+    val result = SQL("INSERT INTO t (a,b) VALUES ({a},{b})")
+      .withParamsMap(Map("a" -> 1, "b" -> "two"))
+      .substituteParams
+    result should include("1")
+    result should include("'two'")
+  }
+
+  // ─── withParams (explicit ParamVal binding) ───────────────────────────────────
+
+  "SQL.withParams" should "preserve explicitly provided ParamVal values unchanged" in {
+    val swp = SQL("SELECT {x}").withParams("x" -> StrParam("raw"))
+    swp.params should contain("x" -> StrParam("raw"))
+  }
+
+  it should "allow explicit NullParam without using the 'NULL' sentinel string" in {
+    val swp = SQL("SELECT {x}").withParams("x" -> NullParam)
+    swp.params should contain("x" -> NullParam)
+    swp.substituteParams should include("NULL")
+  }
+
+  // ─── withOutParams ────────────────────────────────────────────────────────────
+
+  "SqlWithParam.withOutParams" should "store out-parameter definitions for callable statements" in {
+    val base = SQL("CALL proc({p})").withParams("p" -> IntParam(1))
+    val swp  = base.withOutParams(Seq("result" -> java.sql.Types.INTEGER))
+    swp.outParams should contain("result" -> java.sql.Types.INTEGER)
+    swp.params    should contain("p"      -> IntParam(1))
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/jdbc/db/SqlWithParamSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/db/SqlWithParamSpec.scala
@@ -8,9 +8,8 @@ import java.util.UUID
 
 /** Unit-level regression tests for SQL interpolation and parameter mapping.
   *
-  * Covers `SQL.withParamsMap` type-coercion logic and `SqlWithParam.substituteParams`
-  * string-rendering for every `ParamVal` variant.  These tests require no database — all
-  * assertions are over pure in-memory data structures.
+  * Covers `SQL.withParamsMap` type-coercion logic and `SqlWithParam.substituteParams` string-rendering for every `ParamVal`
+  * variant. These tests require no database — all assertions are over pure in-memory data structures.
   *
   * Protects against regressions in:
   *   - type-dispatch in `withParamsMap` (wrong ParamVal produced for a Scala type)
@@ -114,7 +113,7 @@ class SqlWithParamSpec extends AnyFlatSpec with Matchers {
   it should "render BooleanParam as a bare boolean literal" in {
     val resultTrue  = SQL("{f}").withParamsMap(Map("f" -> true)).substituteParams.trim
     val resultFalse = SQL("{f}").withParamsMap(Map("f" -> false)).substituteParams.trim
-    resultTrue  shouldBe "true"
+    resultTrue shouldBe "true"
     resultFalse shouldBe "false"
   }
 
@@ -168,6 +167,6 @@ class SqlWithParamSpec extends AnyFlatSpec with Matchers {
     val base = SQL("CALL proc({p})").withParams("p" -> IntParam(1))
     val swp  = base.withOutParams(Seq("result" -> java.sql.Types.INTEGER))
     swp.outParams should contain("result" -> java.sql.Types.INTEGER)
-    swp.params    should contain("p"      -> IntParam(1))
+    swp.params should contain("p" -> IntParam(1))
   }
 }


### PR DESCRIPTION
## Summary

- Extends `ResourceFutSpec` with 14 new cases covering the happy path, acquire failure, release call-count invariants, same-exception suppression guard, and all combinators (`pure`, `liftFuture`, `map`, `flatMap`)
- Adds new `SqlWithParamSpec` — a pure, DB-free suite (23 tests) that locks in `withParamsMap` type-coercion and `substituteParams` SQL rendering for every `ParamVal` variant (`Int`, `Long`, `Double`, `Boolean`, `String`, `Date`, `UUID`, `Null`) plus `withParams` and `withOutParams`
- All 41 new tests are deterministic, require no database, and complete in < 200 ms

## Changes

- `src/test/scala/org/galaxio/gatling/jdbc/db/ResourceFutSpec.scala` — extended with lifecycle, combinator, and edge-case coverage
- `src/test/scala/org/galaxio/gatling/jdbc/db/SqlWithParamSpec.scala` — new file; pure unit tests for SQL interpolation and parameter binding

## Testing

Run with:
```
sbt "testOnly org.galaxio.gatling.jdbc.db.ResourceFutSpec org.galaxio.gatling.jdbc.db.SqlWithParamSpec"
```
All 41 tests pass. No database required.

Fixes #34