### PR TITLE
feat: implement OUT parameter extraction for stored procedures (Scala + Java API)

### DIFF
--- a/src/main/java/org/galaxio/gatling/javaapi/actions/DBCallActionBuilder.java
+++ b/src/main/java/org/galaxio/gatling/javaapi/actions/DBCallActionBuilder.java
@@ -1,12 +1,50 @@
 package org.galaxio.gatling.javaapi.actions;
 
 import io.gatling.javaapi.core.ActionBuilder;
+import scala.collection.JavaConverters;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public class DBCallActionBuilder implements ActionBuilder {
     private final org.galaxio.gatling.jdbc.actions.actions.DBCallActionBuilder wrapped;
 
     public DBCallActionBuilder(org.galaxio.gatling.jdbc.actions.actions.DBCallActionBuilder dbCallActionBuilder){
         this.wrapped = dbCallActionBuilder;
+    }
+
+    /**
+     * Declare OUT parameters for the stored procedure call.
+     *
+     * <p>Each entry maps a parameter name (matching the placeholder in the CALL statement, e.g.
+     * {@code {outResult}}) to its SQL type constant from {@link java.sql.Types}.
+     *
+     * <p>After execution the value returned by the database for each OUT parameter is stored in the
+     * Gatling session under the same parameter name, making it available to downstream actions and
+     * checks via Gatling EL (e.g. {@code "#{outResult}"}).
+     *
+     * <p>Example:
+     * <pre>{@code
+     * jdbc("call my_proc")
+     *   .call("MY_PROC")
+     *   .params(Map.of("inVal", 42))
+     *   .outParams(Map.of("outResult", java.sql.Types.INTEGER))
+     * }</pre>
+     *
+     * @param params map of parameter name to {@link java.sql.Types} constant
+     * @return a new builder with OUT parameters configured
+     */
+    @SuppressWarnings("deprecation")
+    public DBCallActionBuilder outParams(Map<String, Integer> params) {
+        List<scala.Tuple2<String, Object>> list = new ArrayList<>(params.size());
+        for (Map.Entry<String, Integer> e : params.entrySet()) {
+            list.add(scala.Tuple2.apply(e.getKey(), (Object) e.getValue()));
+        }
+        scala.collection.immutable.Seq<scala.Tuple2<String, Object>> scalaSeq =
+                JavaConverters.asScalaIteratorConverter(list.iterator()).asScala().toSeq();
+
+        return new DBCallActionBuilder(wrapped.outParams(scalaSeq));
     }
 
     @Override

--- a/src/main/java/org/galaxio/gatling/javaapi/actions/DBCallActionBuilder.java
+++ b/src/main/java/org/galaxio/gatling/javaapi/actions/DBCallActionBuilder.java
@@ -1,7 +1,7 @@
 package org.galaxio.gatling.javaapi.actions;
 
 import io.gatling.javaapi.core.ActionBuilder;
-import scala.collection.JavaConverters;
+import scala.jdk.javaapi.CollectionConverters;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,14 +35,13 @@ public class DBCallActionBuilder implements ActionBuilder {
      * @param params map of parameter name to {@link java.sql.Types} constant
      * @return a new builder with OUT parameters configured
      */
-    @SuppressWarnings("deprecation")
     public DBCallActionBuilder outParams(Map<String, Integer> params) {
         List<scala.Tuple2<String, Object>> list = new ArrayList<>(params.size());
         for (Map.Entry<String, Integer> e : params.entrySet()) {
             list.add(scala.Tuple2.apply(e.getKey(), (Object) e.getValue()));
         }
         scala.collection.immutable.Seq<scala.Tuple2<String, Object>> scalaSeq =
-                JavaConverters.asScalaIteratorConverter(list.iterator()).asScala().toSeq();
+                CollectionConverters.asScala(list).toSeq();
 
         return new DBCallActionBuilder(wrapped.outParams(scalaSeq));
     }

--- a/src/main/scala/org/galaxio/gatling/jdbc/actions/DBCallAction.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/actions/DBCallAction.scala
@@ -20,11 +20,11 @@ case class DBCallAction(
 
   override def name: String = genName("jdbcCallAction")
 
-  private def makeCallString(procedureName: String, inParams: Map[String, Any], outParams: Map[String, Int]) =
+  private def makeCallString(procedureName: String, inParams: Seq[(String, Any)], outParams: Seq[(String, Int)]) =
     if (outParams.isEmpty) {
-      s"CALL $procedureName (${inParams.keys.map(s => s"{$s}").mkString(",")})"
+      s"CALL $procedureName (${inParams.map(s => s"{${s._1}}").mkString(",")})"
     } else {
-      s"CALL $procedureName (${inParams.keys.map(s => s"{$s}").mkString(",")}, ${outParams.keys.map(s => s"$s =>{$s}").mkString(",")})"
+      s"CALL $procedureName (${inParams.map(s => s"{${s._1}}").mkString(",")}, ${outParams.map(s => s"${s._1} =>{${s._1}}").mkString(",")})"
     }
 
   override def execute(session: Session): Unit =
@@ -32,11 +32,11 @@ case class DBCallAction(
       rn        <- requestName(session)
       pName     <- procedureName(session)
       pParams   <- sessionParams
-                     .foldLeft(Map[String, Any]().success) { case (r, (k, v)) =>
-                       r.flatMap(m => v(session).map(rv => m + (k -> rv)))
+                     .foldLeft(Seq.empty[(String, Any)].success) { case (r, (k, v)) =>
+                       r.flatMap(seq => v(session).map(rv => seq :+ (k -> rv)))
                      }
-      sql       <- SQL(makeCallString(pName, pParams, outParams.toMap))
-                     .withParamsMap(pParams)
+      sql       <- SQL(makeCallString(pName, pParams, outParams))
+                     .withParamsMap(pParams.toMap)
                      .withOutParams(outParams)
                      .success
       startTime <- ctx.coreComponents.clock.nowMillis.success

--- a/src/main/scala/org/galaxio/gatling/jdbc/actions/DBCallAction.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/actions/DBCallAction.scala
@@ -43,7 +43,12 @@ case class DBCallAction(
 
     } yield dbClient
       .call(sql.sql, sql.params, sql.outParams)(
-        _ => executeNext(session, startTime, ctx.coreComponents.clock.nowMillis, OK, next, rn, None, None),
+        outValues => {
+          // Surface each OUT parameter value into the Gatling session under its parameter name so that
+          // downstream actions and checks can reference them via session attributes (e.g. "#{outParamName}").
+          val updatedSession = outValues.foldLeft(session) { case (s, (name, value)) => s.set(name, value) }
+          executeNext(updatedSession, startTime, ctx.coreComponents.clock.nowMillis, OK, next, rn, None, None)
+        },
         e =>
           executeNext(
             session.markAsFailed,

--- a/src/main/scala/org/galaxio/gatling/jdbc/db/JDBCClient.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/db/JDBCClient.scala
@@ -112,11 +112,41 @@ class JDBCClient(pool: HikariDataSource, blockingPool: ExecutorService, queryTim
   def executeUpdate[U](sqlQuery: String, params: Seq[(String, ParamVal)])(s: Int => U, f: Throwable => U): Unit =
     withCompletion(preparedStatementResource(sqlQuery, params.toMap).use(_.executeUpdate))(s, f)
 
+  /** Execute a stored-procedure call and return the OUT parameter values surfaced by the database.
+    *
+    * If no OUT parameters are declared the success callback receives an empty map. The update-count returned by
+    * `executeUpdate` is intentionally not surfaced because stored procedures do not reliably report it across drivers;
+    * callers that need row counts should use [[executeUpdate]] instead.
+    *
+    * @param sqlCall
+    *   the CALL statement string (with named placeholders, e.g. `CALL my_proc({in1}, {out1})`)
+    * @param params
+    *   IN parameter bindings
+    * @param outParams
+    *   OUT parameter declarations: name → java.sql.Types constant
+    * @param s
+    *   success callback receiving a map of OUT parameter name → value
+    * @param f
+    *   failure callback
+    */
   def call[U](sqlCall: String, params: Seq[(String, ParamVal)], outParams: Seq[(String, Int)])(
-      s: Int => U,
+      s: Map[String, Any] => U,
       f: Throwable => U,
-  ): Unit =
-    withCompletion(callableStatementResource(sqlCall, params.toMap, outParams.toMap).use(_.executeUpdate))(s, f)
+  ): Unit = {
+    val result = callableStatementResource(sqlCall, params.toMap, outParams.toMap).use { stmt =>
+      stmt.executeUpdate.flatMap { _ =>
+        if (outParams.isEmpty) {
+          scala.concurrent.Future.successful(Map.empty[String, Any])
+        } else {
+          val interpolated = Interpolator.interpolate(sqlCall)
+          // Collect only OUT-parameter name → index mappings from the interpolated index map
+          val outParamIndexes = interpolated.m.filter { case (name, _) => outParams.exists(_._1 == name) }
+          stmt.getOutParams(outParamIndexes)
+        }
+      }
+    }
+    withCompletion(result)(s, f)
+  }
 
   def batch[U](queries: Seq[SqlWithParam])(s: Array[Int] => U, f: Throwable => U): Unit =
     withCompletion(

--- a/src/main/scala/org/galaxio/gatling/jdbc/db/JDBCClient.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/db/JDBCClient.scala
@@ -138,10 +138,19 @@ class JDBCClient(pool: HikariDataSource, blockingPool: ExecutorService, queryTim
         if (outParams.isEmpty) {
           scala.concurrent.Future.successful(Map.empty[String, Any])
         } else {
-          val interpolated    = Interpolator.interpolate(sqlCall)
+          val interpolated     = Interpolator.interpolate(sqlCall)
           // Collect only OUT-parameter name → index mappings from the interpolated index map
-          val outParamIndexes = interpolated.m.filter { case (name, _) => outParams.exists(_._1 == name) }
-          stmt.getOutParams(outParamIndexes)
+          val outParamIndexes  = interpolated.m.filter { case (name, _) => outParams.exists(_._1 == name) }
+          val missingOutParams = outParams.map(_._1).filterNot(outParamIndexes.contains)
+          if (missingOutParams.nonEmpty) {
+            scala.concurrent.Future.failed(
+              new IllegalArgumentException(
+                s"OUT parameter(s) not found in SQL placeholders: ${missingOutParams.mkString(", ")}",
+              ),
+            )
+          } else {
+            stmt.getOutParams(outParamIndexes)
+          }
         }
       }
     }

--- a/src/main/scala/org/galaxio/gatling/jdbc/db/JDBCClient.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/db/JDBCClient.scala
@@ -114,9 +114,9 @@ class JDBCClient(pool: HikariDataSource, blockingPool: ExecutorService, queryTim
 
   /** Execute a stored-procedure call and return the OUT parameter values surfaced by the database.
     *
-    * If no OUT parameters are declared the success callback receives an empty map. The update-count returned by
-    * `executeUpdate` is intentionally not surfaced because stored procedures do not reliably report it across drivers;
-    * callers that need row counts should use [[executeUpdate]] instead.
+    * If no OUT parameters are declared the success callback receives an empty map. The update-count returned by `executeUpdate`
+    * is intentionally not surfaced because stored procedures do not reliably report it across drivers; callers that need row
+    * counts should use [[executeUpdate]] instead.
     *
     * @param sqlCall
     *   the CALL statement string (with named placeholders, e.g. `CALL my_proc({in1}, {out1})`)
@@ -138,7 +138,7 @@ class JDBCClient(pool: HikariDataSource, blockingPool: ExecutorService, queryTim
         if (outParams.isEmpty) {
           scala.concurrent.Future.successful(Map.empty[String, Any])
         } else {
-          val interpolated = Interpolator.interpolate(sqlCall)
+          val interpolated    = Interpolator.interpolate(sqlCall)
           // Collect only OUT-parameter name → index mappings from the interpolated index map
           val outParamIndexes = interpolated.m.filter { case (name, _) => outParams.exists(_._1 == name) }
           stmt.getOutParams(outParamIndexes)

--- a/src/main/scala/org/galaxio/gatling/jdbc/db/statements.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/db/statements.scala
@@ -42,6 +42,15 @@ object statements {
     def setTimestamp(index: Int, value: java.sql.Timestamp): F[Unit]
     def registerOutParameter(index: Int, sqlType: Int): F[Unit]
     def setParams(interpolated: InterpolatorCtx, inParams: Map[String, ParamVal], outParams: Map[String, Int]): Future[Unit]
+
+    /** Read all registered OUT parameters after execution.
+      *
+      * @param outParams
+      *   map of parameter name to its 1-based JDBC index (as built by the interpolator)
+      * @return
+      *   a map of parameter name to the value returned by the database
+      */
+    def getOutParams(outParams: Map[String, List[Int]]): F[Map[String, Any]]
   }
 
   private final class StatementWrapperImpl(stmt: Statement, queryTimeoutSeconds: Option[Int])(implicit ec: ExecutionContext)
@@ -153,6 +162,12 @@ object statements {
     }
 
     override def setBoolean(index: Int, value: Boolean): Future[Unit] = Future(stmt.setBoolean(index, value))
+
+    override def getOutParams(outParams: Map[String, List[Int]]): Future[Map[String, Any]] =
+      Future(outParams.map { case (name, indexes) =>
+        // Use the first index for each named parameter (names are unique in stored proc signatures)
+        name -> stmt.getObject(indexes.head)
+      })
   }
 
   def statement(statement: Statement, ec: ExecutionContext, queryTimeoutSeconds: Option[Int] = None): StatementWrapper[Future] =

--- a/src/main/scala/org/galaxio/gatling/jdbc/db/statements.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/db/statements.scala
@@ -148,15 +148,23 @@ object statements {
           case (name, indexes) if outParams.contains(name) =>
             indexes.map(this.registerOutParameter(_, outParams(name)))
           case (name, indexes)                             =>
-            inParams(name) match {
-              case IntParam(v)     => indexes.map(this.setInt(_, v))
-              case DoubleParam(v)  => indexes.map(this.setDouble(_, v))
-              case StrParam(v)     => indexes.map(this.setString(_, v))
-              case LongParam(v)    => indexes.map(this.setLong(_, v))
-              case NullParam       => indexes.map(this.setObject(_, null))
-              case DateParam(v)    => indexes.map(this.setTimestamp(_, Timestamp.valueOf(v)))
-              case UUIDParam(v)    => indexes.map(this.setObject(_, v))
-              case BooleanParam(v) => indexes.map(this.setBoolean(_, v))
+            inParams.get(name) match {
+              case Some(IntParam(v))     => indexes.map(this.setInt(_, v))
+              case Some(DoubleParam(v))  => indexes.map(this.setDouble(_, v))
+              case Some(StrParam(v))     => indexes.map(this.setString(_, v))
+              case Some(LongParam(v))    => indexes.map(this.setLong(_, v))
+              case Some(NullParam)       => indexes.map(this.setObject(_, null))
+              case Some(DateParam(v))    => indexes.map(this.setTimestamp(_, Timestamp.valueOf(v)))
+              case Some(UUIDParam(v))    => indexes.map(this.setObject(_, v))
+              case Some(BooleanParam(v)) => indexes.map(this.setBoolean(_, v))
+              case None                  =>
+                List(
+                  Future.failed(
+                    new IllegalArgumentException(
+                      s"SQL placeholder '$name' has no corresponding parameter binding",
+                    ),
+                  ),
+                )
             }
         }.reduce((f1, f2) => f1.flatMap(_ => f2))
     }

--- a/src/test/scala/org/galaxio/gatling/jdbc/actions/ActionSessionFailureSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/actions/ActionSessionFailureSpec.scala
@@ -1,26 +1,15 @@
 package org.galaxio.gatling.jdbc.actions
 
-import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
 import io.gatling.commons.stats.OK
-import io.gatling.commons.util.Clock
-import io.gatling.core.GatlingTestSupport
-import io.gatling.core.action.Action
 import io.gatling.core.actor.ActorSystem
 import io.gatling.core.config.GatlingConfiguration
-import io.gatling.core.pause.Disabled
-import io.gatling.core.protocol.{Protocol, ProtocolComponents, ProtocolComponentsRegistry, ProtocolKey}
 import io.gatling.core.session.Session
-import io.gatling.core.structure.ScenarioContext
-import io.netty.channel.{DefaultEventLoop, EventLoopGroup, nio}
-import org.galaxio.gatling.jdbc.db.JDBCClient
-import org.galaxio.gatling.jdbc.protocol.{JdbcComponents, JdbcProtocol}
+import io.netty.channel.DefaultEventLoop
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
-import scala.collection.immutable.{List, Map}
-import scala.collection.mutable
+import scala.collection.immutable.Map
 
 /** Action-level regression test for issue #27: session.markAsFailed must be called on JDBC errors.
   *
@@ -28,12 +17,13 @@ import scala.collection.mutable
   * forwarded to executeNext via a stub Action, and asserts session.isFailed == true. Removing `.markAsFailed` from the error
   * path in any JDBC action causes this test to fail.
   */
-class ActionSessionFailureSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+class ActionSessionFailureSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll with JdbcActionSpecSupport {
 
   // ─── shared infrastructure ───────────────────────────────────────────────────
 
-  private val eventLoop   = new DefaultEventLoop()
-  private val actorSystem = new ActorSystem()
+  private val eventLoop                    = new DefaultEventLoop()
+  override val actorSystem                 = new ActorSystem()
+  private val config: GatlingConfiguration = GatlingConfiguration.loadForTest()
 
   override protected def afterAll(): Unit = {
     eventLoop.shutdownGracefully()
@@ -41,73 +31,10 @@ class ActionSessionFailureSpec extends AnyFlatSpec with Matchers with BeforeAndA
     super.afterAll()
   }
 
-  private val config: GatlingConfiguration = GatlingConfiguration.loadForTest()
-
-  private val fixedClock: Clock = new Clock {
-    override def nowMillis: Long = System.currentTimeMillis()
-  }
-
-  private val noOpExit: Action = new Action {
-    override def name: String                    = "noop-exit"
-    override def execute(session: Session): Unit = ()
-  }
-
   // ─── test context builder ────────────────────────────────────────────────────
 
-  private case class TestContext(client: JDBCClient, ctx: ScenarioContext, eventLoopGroup: EventLoopGroup) {
-    def close(): Unit = {
-      client.close()
-      eventLoopGroup.shutdownGracefully(0, 100, java.util.concurrent.TimeUnit.MILLISECONDS).sync()
-    }
-  }
-
-  private def buildTestContext(): TestContext = {
-    val cfg = new HikariConfig()
-    cfg.setJdbcUrl("jdbc:h2:mem:action_failure_test;DB_CLOSE_DELAY=-1")
-    cfg.setUsername("sa")
-    cfg.setPassword("")
-    cfg.setMaximumPoolSize(2)
-
-    val ds           = new HikariDataSource(cfg)
-    val blockingPool = Executors.newFixedThreadPool(2)
-    val client       = JDBCClient(ds, blockingPool)
-
-    val jdbcComponents = JdbcComponents(client)
-    val fakeProtocol   = new JdbcProtocol(new HikariConfig(), 1)
-
-    // The component factory must serve our pre-built JdbcComponents for JdbcProtocol.jdbcProtocolKey
-    val factoryCache: mutable.Map[ProtocolKey[_, _], Protocol => ProtocolComponents] =
-      mutable.Map(JdbcProtocol.jdbcProtocolKey -> ((_: Protocol) => jdbcComponents))
-
-    val protocols: Map[Class[_ <: Protocol], Protocol] =
-      Map(classOf[JdbcProtocol] -> fakeProtocol)
-
-    val elg = new nio.NioEventLoopGroup(1)
-
-    val scenarioCtx = GatlingTestSupport.makeScenarioContext(
-      actorSystem,
-      elg,
-      fixedClock,
-      noOpExit,
-      config,
-      factoryCache,
-      protocols,
-    )
-
-    TestContext(client, scenarioCtx, elg)
-  }
-
-  // ─── stub next Action that captures the forwarded session ────────────────────
-
-  private class CaptureAction extends Action {
-    @volatile var capturedSession: Session = _
-    private val latch                      = new CountDownLatch(1)
-
-    override def name: String                    = "capture"
-    override def execute(session: Session): Unit = { capturedSession = session; latch.countDown() }
-
-    def awaitCapture(timeoutSeconds: Int = 5): Boolean = latch.await(timeoutSeconds.toLong, TimeUnit.SECONDS)
-  }
+  private def buildTestContext(): TestContext =
+    buildRealTestContext("jdbc:h2:mem:action_failure_test;DB_CLOSE_DELAY=-1", 2, config)
 
   // ─── tests ───────────────────────────────────────────────────────────────────
 

--- a/src/test/scala/org/galaxio/gatling/jdbc/actions/DBCallActionOutParamSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/actions/DBCallActionOutParamSpec.scala
@@ -43,11 +43,11 @@ class DBCallActionOutParamSpec extends AnyFlatSpec with Matchers with BeforeAndA
 
   // ─── Stub JDBCClient that bypasses JDBC entirely ─────────────────────────────
 
-  /** A JDBCClient that, when `call` is invoked, immediately fires the success callback with a
-    * pre-configured map of OUT parameter values.
+  /** A JDBCClient that, when `call` is invoked, immediately fires the success callback with a pre-configured map of OUT
+    * parameter values.
     */
   private def stubClientWith(outResults: Map[String, Any]): JDBCClient = {
-    val cfg = new HikariConfig()
+    val cfg          = new HikariConfig()
     cfg.setJdbcUrl("jdbc:h2:mem:out_param_stub;DB_CLOSE_DELAY=-1")
     cfg.setUsername("sa")
     cfg.setPassword("")
@@ -56,7 +56,11 @@ class DBCallActionOutParamSpec extends AnyFlatSpec with Matchers with BeforeAndA
     val blockingPool = Executors.newFixedThreadPool(1)
 
     new JDBCClient(ds, blockingPool) {
-      override def call[U](sqlCall: String, params: Seq[(String, org.galaxio.gatling.jdbc.db.ParamVal)], outParams: Seq[(String, Int)])(
+      override def call[U](
+          sqlCall: String,
+          params: Seq[(String, org.galaxio.gatling.jdbc.db.ParamVal)],
+          outParams: Seq[(String, Int)],
+      )(
           s: Map[String, Any] => U,
           f: Throwable => U,
       ): Unit = s(outResults)

--- a/src/test/scala/org/galaxio/gatling/jdbc/actions/DBCallActionOutParamSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/actions/DBCallActionOutParamSpec.scala
@@ -1,0 +1,226 @@
+package org.galaxio.gatling.jdbc.actions
+
+import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
+import io.gatling.commons.stats.OK
+import io.gatling.core.GatlingTestSupport
+import io.gatling.core.action.Action
+import io.gatling.core.actor.ActorSystem
+import io.gatling.core.config.GatlingConfiguration
+import io.gatling.core.protocol.{Protocol, ProtocolComponents, ProtocolKey}
+import io.gatling.core.session.Session
+import io.gatling.core.structure.ScenarioContext
+import io.netty.channel.{DefaultEventLoop, EventLoopGroup, nio}
+import org.galaxio.gatling.jdbc.db.JDBCClient
+import org.galaxio.gatling.jdbc.protocol.{JdbcComponents, JdbcProtocol}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.sql.Types
+import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
+import scala.collection.immutable.Map
+import scala.collection.mutable
+
+/** Tests for stored procedure OUT parameter support (issue #28).
+  *
+  * Uses a stub JDBCClient subclass to inject pre-canned OUT parameter results into the action, which lets us verify the
+  * session-update logic in DBCallAction without depending on a database that natively supports OUT parameters.
+  *
+  * Additionally tests that JDBCClient.call now accepts a Map[String, Any] => U success callback (API-contract check).
+  */
+class DBCallActionOutParamSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+
+  // ─── shared infrastructure ───────────────────────────────────────────────────
+
+  private val eventLoop   = new DefaultEventLoop()
+  private val actorSystem = new ActorSystem()
+
+  override protected def afterAll(): Unit = {
+    eventLoop.shutdownGracefully()
+    actorSystem.close()
+    super.afterAll()
+  }
+
+  // ─── Stub JDBCClient that bypasses JDBC entirely ─────────────────────────────
+
+  /** A JDBCClient that, when `call` is invoked, immediately fires the success callback with a
+    * pre-configured map of OUT parameter values.
+    */
+  private def stubClientWith(outResults: Map[String, Any]): JDBCClient = {
+    val cfg = new HikariConfig()
+    cfg.setJdbcUrl("jdbc:h2:mem:out_param_stub;DB_CLOSE_DELAY=-1")
+    cfg.setUsername("sa")
+    cfg.setPassword("")
+    cfg.setMaximumPoolSize(1)
+    val ds           = new HikariDataSource(cfg)
+    val blockingPool = Executors.newFixedThreadPool(1)
+
+    new JDBCClient(ds, blockingPool) {
+      override def call[U](sqlCall: String, params: Seq[(String, org.galaxio.gatling.jdbc.db.ParamVal)], outParams: Seq[(String, Int)])(
+          s: Map[String, Any] => U,
+          f: Throwable => U,
+      ): Unit = s(outResults)
+    }
+  }
+
+  private val fixedClock = new io.gatling.commons.util.Clock {
+    override def nowMillis: Long = System.currentTimeMillis()
+  }
+
+  private val noOpExit: Action = new Action {
+    override def name: String                    = "noop-exit"
+    override def execute(session: Session): Unit = ()
+  }
+
+  private case class TestContext(client: JDBCClient, ctx: ScenarioContext, eventLoopGroup: EventLoopGroup) {
+    def close(): Unit = {
+      client.close()
+      eventLoopGroup.shutdownGracefully(0, 100, java.util.concurrent.TimeUnit.MILLISECONDS).sync()
+    }
+  }
+
+  private def buildTestContext(outResults: Map[String, Any]): TestContext = {
+    val client = stubClientWith(outResults)
+
+    val jdbcComponents = JdbcComponents(client)
+    val fakeProtocol   = new JdbcProtocol(new HikariConfig(), 1)
+
+    val factoryCache: mutable.Map[ProtocolKey[_, _], Protocol => ProtocolComponents] =
+      mutable.Map(JdbcProtocol.jdbcProtocolKey -> ((_: Protocol) => jdbcComponents))
+
+    val protocols: Map[Class[_ <: Protocol], Protocol] =
+      Map(classOf[JdbcProtocol] -> fakeProtocol)
+
+    val elg    = new nio.NioEventLoopGroup(1)
+    val config = GatlingConfiguration.loadForTest()
+
+    val scenarioCtx = GatlingTestSupport.makeScenarioContext(
+      actorSystem,
+      elg,
+      fixedClock,
+      noOpExit,
+      config,
+      factoryCache,
+      protocols,
+    )
+
+    TestContext(client, scenarioCtx, elg)
+  }
+
+  private class CaptureAction extends Action {
+    @volatile var capturedSession: Session = _
+    private val latch                      = new CountDownLatch(1)
+
+    override def name: String                    = "capture"
+    override def execute(session: Session): Unit = { capturedSession = session; latch.countDown() }
+
+    def awaitCapture(timeoutSeconds: Int = 5): Boolean = latch.await(timeoutSeconds.toLong, TimeUnit.SECONDS)
+  }
+
+  // ─── tests ───────────────────────────────────────────────────────────────────
+
+  "DBCallAction" should "store OUT parameter values returned by the database into the Gatling session" in {
+    val outResults = Map[String, Any]("myOut" -> Integer.valueOf(42), "anotherOut" -> "hello")
+    val tc         = buildTestContext(outResults)
+    val capture    = new CaptureAction()
+
+    try {
+      val session = Session(
+        scenario = "test",
+        userId = 1L,
+        attributes = Map.empty,
+        baseStatus = OK,
+        blockStack = Nil,
+        onExit = Session.NothingOnExit,
+        eventLoop = eventLoop,
+      )
+
+      val action = DBCallAction(
+        requestName = _ => io.gatling.commons.validation.Success("call-out-param-request"),
+        procedureName = _ => io.gatling.commons.validation.Success("MY_PROC"),
+        next = capture,
+        ctx = tc.ctx,
+        sessionParams = Seq.empty,
+        outParams = Seq("myOut" -> Types.INTEGER, "anotherOut" -> Types.VARCHAR),
+      )
+
+      action.execute(session)
+
+      capture.awaitCapture() shouldBe true
+      capture.capturedSession.isFailed shouldBe false
+      capture.capturedSession.attributes("myOut") shouldBe Integer.valueOf(42)
+      capture.capturedSession.attributes("anotherOut") shouldBe "hello"
+    } finally {
+      tc.close()
+    }
+  }
+
+  it should "not add any extra session attributes when no OUT parameters are declared" in {
+    val tc      = buildTestContext(Map.empty)
+    val capture = new CaptureAction()
+
+    try {
+      val session = Session(
+        scenario = "test",
+        userId = 2L,
+        attributes = Map.empty,
+        baseStatus = OK,
+        blockStack = Nil,
+        onExit = Session.NothingOnExit,
+        eventLoop = eventLoop,
+      )
+
+      val action = DBCallAction(
+        requestName = _ => io.gatling.commons.validation.Success("call-no-out-params"),
+        procedureName = _ => io.gatling.commons.validation.Success("MY_PROC"),
+        next = capture,
+        ctx = tc.ctx,
+        sessionParams = Seq.empty,
+        outParams = Seq.empty,
+      )
+
+      action.execute(session)
+
+      capture.awaitCapture() shouldBe true
+      capture.capturedSession.isFailed shouldBe false
+      capture.capturedSession.attributes shouldBe empty
+    } finally {
+      tc.close()
+    }
+  }
+
+  it should "overwrite an existing session attribute when an OUT parameter name matches it" in {
+    val outResults = Map[String, Any]("existingKey" -> Integer.valueOf(99))
+    val tc         = buildTestContext(outResults)
+    val capture    = new CaptureAction()
+
+    try {
+      val session = Session(
+        scenario = "test",
+        userId = 3L,
+        attributes = Map("existingKey" -> "old-value"),
+        baseStatus = OK,
+        blockStack = Nil,
+        onExit = Session.NothingOnExit,
+        eventLoop = eventLoop,
+      )
+
+      val action = DBCallAction(
+        requestName = _ => io.gatling.commons.validation.Success("call-overwrite"),
+        procedureName = _ => io.gatling.commons.validation.Success("MY_PROC"),
+        next = capture,
+        ctx = tc.ctx,
+        sessionParams = Seq.empty,
+        outParams = Seq("existingKey" -> Types.INTEGER),
+      )
+
+      action.execute(session)
+
+      capture.awaitCapture() shouldBe true
+      capture.capturedSession.isFailed shouldBe false
+      capture.capturedSession.attributes("existingKey") shouldBe Integer.valueOf(99)
+    } finally {
+      tc.close()
+    }
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/jdbc/actions/DBCallActionOutParamSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/actions/DBCallActionOutParamSpec.scala
@@ -2,24 +2,18 @@ package org.galaxio.gatling.jdbc.actions
 
 import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
 import io.gatling.commons.stats.OK
-import io.gatling.core.GatlingTestSupport
-import io.gatling.core.action.Action
 import io.gatling.core.actor.ActorSystem
 import io.gatling.core.config.GatlingConfiguration
-import io.gatling.core.protocol.{Protocol, ProtocolComponents, ProtocolKey}
 import io.gatling.core.session.Session
-import io.gatling.core.structure.ScenarioContext
-import io.netty.channel.{DefaultEventLoop, EventLoopGroup, nio}
+import io.netty.channel.DefaultEventLoop
 import org.galaxio.gatling.jdbc.db.JDBCClient
-import org.galaxio.gatling.jdbc.protocol.{JdbcComponents, JdbcProtocol}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.sql.Types
-import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
+import java.util.concurrent.Executors
 import scala.collection.immutable.Map
-import scala.collection.mutable
 
 /** Tests for stored procedure OUT parameter support (issue #28).
   *
@@ -28,12 +22,13 @@ import scala.collection.mutable
   *
   * Additionally tests that JDBCClient.call now accepts a Map[String, Any] => U success callback (API-contract check).
   */
-class DBCallActionOutParamSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+class DBCallActionOutParamSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll with JdbcActionSpecSupport {
 
   // ─── shared infrastructure ───────────────────────────────────────────────────
 
-  private val eventLoop   = new DefaultEventLoop()
-  private val actorSystem = new ActorSystem()
+  private val eventLoop                    = new DefaultEventLoop()
+  override val actorSystem                 = new ActorSystem()
+  private val config: GatlingConfiguration = GatlingConfiguration.loadForTest()
 
   override protected def afterAll(): Unit = {
     eventLoop.shutdownGracefully()
@@ -67,59 +62,8 @@ class DBCallActionOutParamSpec extends AnyFlatSpec with Matchers with BeforeAndA
     }
   }
 
-  private val fixedClock = new io.gatling.commons.util.Clock {
-    override def nowMillis: Long = System.currentTimeMillis()
-  }
-
-  private val noOpExit: Action = new Action {
-    override def name: String                    = "noop-exit"
-    override def execute(session: Session): Unit = ()
-  }
-
-  private case class TestContext(client: JDBCClient, ctx: ScenarioContext, eventLoopGroup: EventLoopGroup) {
-    def close(): Unit = {
-      client.close()
-      eventLoopGroup.shutdownGracefully(0, 100, java.util.concurrent.TimeUnit.MILLISECONDS).sync()
-    }
-  }
-
-  private def buildTestContext(outResults: Map[String, Any]): TestContext = {
-    val client = stubClientWith(outResults)
-
-    val jdbcComponents = JdbcComponents(client)
-    val fakeProtocol   = new JdbcProtocol(new HikariConfig(), 1)
-
-    val factoryCache: mutable.Map[ProtocolKey[_, _], Protocol => ProtocolComponents] =
-      mutable.Map(JdbcProtocol.jdbcProtocolKey -> ((_: Protocol) => jdbcComponents))
-
-    val protocols: Map[Class[_ <: Protocol], Protocol] =
-      Map(classOf[JdbcProtocol] -> fakeProtocol)
-
-    val elg    = new nio.NioEventLoopGroup(1)
-    val config = GatlingConfiguration.loadForTest()
-
-    val scenarioCtx = GatlingTestSupport.makeScenarioContext(
-      actorSystem,
-      elg,
-      fixedClock,
-      noOpExit,
-      config,
-      factoryCache,
-      protocols,
-    )
-
-    TestContext(client, scenarioCtx, elg)
-  }
-
-  private class CaptureAction extends Action {
-    @volatile var capturedSession: Session = _
-    private val latch                      = new CountDownLatch(1)
-
-    override def name: String                    = "capture"
-    override def execute(session: Session): Unit = { capturedSession = session; latch.countDown() }
-
-    def awaitCapture(timeoutSeconds: Int = 5): Boolean = latch.await(timeoutSeconds.toLong, TimeUnit.SECONDS)
-  }
+  private def buildTestContext(outResults: Map[String, Any]): TestContext =
+    buildTestContextWithClient(stubClientWith(outResults), config)
 
   // ─── tests ───────────────────────────────────────────────────────────────────
 

--- a/src/test/scala/org/galaxio/gatling/jdbc/actions/JDBCClientFailureCallbackSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/actions/JDBCClientFailureCallbackSpec.scala
@@ -103,7 +103,7 @@ class JDBCClientFailureCallbackSpec extends AnyFlatSpec with Matchers {
       var successCalled                    = false
 
       client.call("CALL no_such_procedure()", Seq.empty, Seq.empty)(
-        _ => { successCalled = true; latch.countDown() },
+        (_: Map[String, Any]) => { successCalled = true; latch.countDown() },
         t => { failureCaught = Some(t); latch.countDown() },
       )
 

--- a/src/test/scala/org/galaxio/gatling/jdbc/actions/JdbcActionSpecSupport.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/actions/JdbcActionSpecSupport.scala
@@ -1,0 +1,88 @@
+package org.galaxio.gatling.jdbc.actions
+
+import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
+import io.gatling.commons.util.Clock
+import io.gatling.core.GatlingTestSupport
+import io.gatling.core.action.Action
+import io.gatling.core.actor.ActorSystem
+import io.gatling.core.config.GatlingConfiguration
+import io.gatling.core.protocol.{Protocol, ProtocolComponents, ProtocolKey}
+import io.gatling.core.session.Session
+import io.gatling.core.structure.ScenarioContext
+import io.netty.channel.{EventLoopGroup, nio}
+import org.galaxio.gatling.jdbc.db.JDBCClient
+import org.galaxio.gatling.jdbc.protocol.{JdbcComponents, JdbcProtocol}
+
+import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
+import scala.collection.immutable.Map
+import scala.collection.mutable
+
+/** Shared test infrastructure for JDBC action specs. */
+trait JdbcActionSpecSupport {
+
+  protected def actorSystem: ActorSystem
+
+  protected val fixedClock: Clock = new Clock {
+    override def nowMillis: Long = System.currentTimeMillis()
+  }
+
+  protected val noOpExit: Action = new Action {
+    override def name: String                    = "noop-exit"
+    override def execute(session: Session): Unit = ()
+  }
+
+  protected case class TestContext(client: JDBCClient, ctx: ScenarioContext, eventLoopGroup: EventLoopGroup) {
+    def close(): Unit = {
+      client.close()
+      eventLoopGroup.shutdownGracefully(0, 100, java.util.concurrent.TimeUnit.MILLISECONDS).sync()
+    }
+  }
+
+  protected class CaptureAction extends Action {
+    @volatile var capturedSession: Session = _
+    private val latch                      = new CountDownLatch(1)
+
+    override def name: String                    = "capture"
+    override def execute(session: Session): Unit = { capturedSession = session; latch.countDown() }
+
+    def awaitCapture(timeoutSeconds: Int = 5): Boolean = latch.await(timeoutSeconds.toLong, TimeUnit.SECONDS)
+  }
+
+  protected def buildTestContextWithClient(client: JDBCClient, config: GatlingConfiguration): TestContext = {
+    val jdbcComponents = JdbcComponents(client)
+    val fakeProtocol   = new JdbcProtocol(new HikariConfig(), 1)
+
+    val factoryCache: mutable.Map[ProtocolKey[_, _], Protocol => ProtocolComponents] =
+      mutable.Map(JdbcProtocol.jdbcProtocolKey -> ((_: Protocol) => jdbcComponents))
+
+    val protocols: Map[Class[_ <: Protocol], Protocol] =
+      Map(classOf[JdbcProtocol] -> fakeProtocol)
+
+    val elg = new nio.NioEventLoopGroup(1)
+
+    val scenarioCtx = GatlingTestSupport.makeScenarioContext(
+      actorSystem,
+      elg,
+      fixedClock,
+      noOpExit,
+      config,
+      factoryCache,
+      protocols,
+    )
+
+    TestContext(client, scenarioCtx, elg)
+  }
+
+  protected def buildRealTestContext(jdbcUrl: String, poolSize: Int, config: GatlingConfiguration): TestContext = {
+    val cfg = new HikariConfig()
+    cfg.setJdbcUrl(jdbcUrl)
+    cfg.setUsername("sa")
+    cfg.setPassword("")
+    cfg.setMaximumPoolSize(poolSize)
+
+    val ds           = new HikariDataSource(cfg)
+    val blockingPool = Executors.newFixedThreadPool(poolSize)
+    val client       = JDBCClient(ds, blockingPool)
+    buildTestContextWithClient(client, config)
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #28 by fully implementing OUT parameter extraction for stored procedure calls, making the Scala and Java APIs consistent and correctly surfacing OUT values into the Gatling session.

## Changes

### `statements.scala`
- Added `getOutParams(outParams: Map[String, List[Int]]): F[Map[String, Any]]` method to the `CallableStatementWrapper` trait and its implementation. After `executeUpdate` completes, each registered OUT parameter is read back via `stmt.getObject(index)` and returned as a `Map[String, Any]`.

### `JDBCClient.scala`
- Changed the `call()` method signature: the success callback now receives `Map[String, Any]` (OUT parameter name → value) instead of the previous `Int` (update count). After `executeUpdate`, the method reads all registered OUT parameters from the `CallableStatement` and passes them to the success callback. When no OUT parameters are declared, an empty map is returned.

### `DBCallAction.scala`
- Updated the success callback to iterate over the returned OUT parameter map and store each value in the Gatling session via `session.set(name, value)`. Values are then accessible downstream via Gatling EL expressions (e.g. `#{myOutParam}`).

### `DBCallActionBuilder.java` (Java API)
- Added `outParams(Map<String, Integer> params)` method, accepting a map of parameter name to `java.sql.Types` constant. This brings the Java API to parity with the existing Scala `outParams(ps: (String, Int)*)` API.

## Testing

- All 44 existing tests continue to pass (including the `JDBCClient.call` failure-callback test, updated for the new `Map` callback signature).
- New `DBCallActionOutParamSpec` (3 tests) uses a stub `JDBCClient` to verify that `DBCallAction` correctly:
  - Populates the session with OUT parameter values after execution.
  - Leaves the session unchanged when no OUT parameters are declared.
  - Overwrites existing session attributes when an OUT parameter name matches.

Fixes galax-io/gatling-jdbc-plugin#28