### PR TITLE
fix(docs): replace unresolvable Scaladoc links in JdbcProtocolBuilder

### DIFF
--- a/src/main/scala/org/galaxio/gatling/jdbc/protocol/JdbcProtocolBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/protocol/JdbcProtocolBuilder.scala
@@ -59,8 +59,8 @@ final case class JdbcProtocolBuilderConnectionSettingsStep(
 
   /** Sets the query timeout for all JDBC statements.
     * @param newValue
-    *   timeout duration. Sub-second values are rounded up to 1 second. Use [[scala.None]] (omit this setting) for no timeout.
-    *   Passing [[scala.concurrent.duration.Duration.Zero]] is equivalent to no timeout (JDBC semantics).
+    *   timeout duration. Sub-second values are rounded up to 1 second. Omit this setting for no timeout. Passing
+    *   `Duration.Zero` is equivalent to no timeout (JDBC semantics).
     */
   def queryTimeout(newValue: FiniteDuration): JdbcProtocolBuilderConnectionSettingsStep = {
     require(newValue >= Duration.Zero, "queryTimeout must be non-negative")


### PR DESCRIPTION
## Problem

`[[scala.None]]` and `[[scala.concurrent.duration.Duration.Zero]]` in `JdbcProtocolBuilder.scala` fail Scaladoc generation with `-Xfatal-warnings`:

```
Could not find any member to link for "scala.None"
Could not find any member to link for "scala.concurrent.duration.Duration.Zero"
```

This breaks the `Release (tag-driven)` job on every push to `main`.

## Fix

Replace the broken `[[...]]` cross-references with plain-text equivalents. No behaviour change.

Fixes pre-existing main branch failure (first observed before #43).