### PR TITLE
docs: fix README inaccuracies (#23, #30, #31, #32)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ class JdbcSimulation extends Simulation {
 ### Minimal Scenario — Java
 
 ```java
-import static org.galaxio.gatling.jdbc.javaapi.JdbcDsl.*;
+import static org.galaxio.gatling.javaapi.JdbcDsl.*;
 import static io.gatling.javaapi.core.CoreDsl.*;
 
 public class JdbcSimulation extends Simulation {
@@ -117,7 +117,7 @@ public class JdbcSimulation extends Simulation {
 ### Minimal Scenario — Kotlin
 
 ```kotlin
-import org.galaxio.gatling.jdbc.javaapi.JdbcDsl.*
+import org.galaxio.gatling.javaapi.JdbcDsl.*
 import io.gatling.javaapi.core.CoreDsl.*
 
 class JdbcSimulation : Simulation() {

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ JDBC protocol plugin for [Gatling](https://gatling.io/) load testing framework. 
 
 - [Compatibility](#compatibility)
 - [Installation](#installation)
+- [Database Driver Dependencies](#database-driver-dependencies)
 - [Quick Start](#quick-start)
 - [Protocol Configuration](#protocol-configuration)
 - [Actions](#actions)
@@ -54,6 +55,50 @@ gatling("org.galaxio:gatling-jdbc-plugin_2.13:<version>")
   <scope>test</scope>
 </dependency>
 ```
+
+## Database Driver Dependencies
+
+This plugin does **not** bundle vendor JDBC drivers. You must add the driver for your database separately.
+
+### PostgreSQL
+
+```scala
+// sbt
+libraryDependencies += "org.postgresql" % "postgresql" % "42.7.4" % Test
+```
+```kotlin
+// Gradle Kotlin DSL
+gatling("org.postgresql:postgresql:42.7.4")
+```
+```xml
+<!-- Maven -->
+<dependency>
+  <groupId>org.postgresql</groupId>
+  <artifactId>postgresql</artifactId>
+  <version>42.7.4</version>
+  <scope>test</scope>
+</dependency>
+```
+
+### MySQL / MariaDB
+
+```scala
+libraryDependencies += "com.mysql" % "mysql-connector-j" % "9.3.0" % Test
+```
+
+### Microsoft SQL Server
+
+```scala
+libraryDependencies += "com.microsoft.sqlserver" % "mssql-jdbc" % "12.10.0.jre11" % Test
+```
+
+### Oracle
+
+```scala
+libraryDependencies += "com.oracle.database.jdbc" % "ojdbc11" % "23.7.0.25.01" % Test
+```
+
+> **Note:** The quick-start examples below use PostgreSQL. Add the corresponding driver dependency before running them.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -340,8 +340,8 @@ sbt compile
 # Run unit tests
 sbt test
 
-# Run integration tests (requires Docker)
-sbt "Test / testOnly -- -n org.galaxio.gatling.jdbc.tags.DockerTest"
+# Run all tests (unit + integration; integration tests start PostgreSQL via Testcontainers)
+sbt test
 
 # Run Gatling example simulation (H2)
 sbt "Gatling / testOnly org.galaxio.performance.jdbc.test.DebugTest"

--- a/README.md
+++ b/README.md
@@ -26,10 +26,9 @@ JDBC protocol plugin for [Gatling](https://gatling.io/) load testing framework. 
 
 | Plugin Version | Gatling | Scala | Java |
 |---|---|---|---|
-| 0.x.y-latest | 3.13.x | 2.13 | 17+ |
-| 0.x.y | 3.11.x | 2.13 | 17+ |
+| 0.x.y | 3.13.x | 2.13 | 17+ |
 
-> **Branch strategy:** `main` targets Gatling 3.11.x, `latest/gatling` targets Gatling 3.13.x.
+> **Branch strategy:** `main` targets Gatling 3.13.x.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Fixes four documentation issues in a single PR, one commit per issue:

- **#30** — Compatibility matrix incorrectly stated `main` targets Gatling 3.11.x; updated to 3.13.x to match `project/Dependencies.scala`
- **#31** — Java/Kotlin quick-start imports used `org.galaxio.gatling.jdbc.javaapi` instead of the real package `org.galaxio.gatling.javaapi`
- **#32** — Contributing section referenced `sbt "Test / testOnly -- -n org.galaxio.gatling.jdbc.tags.DockerTest"` which does not exist; replaced with `sbt test` (integration tests run via Testcontainers automatically)
- **#23** — Added a **Database Driver Dependencies** section with copy-paste snippets for PostgreSQL, MySQL, SQL Server, and Oracle (sbt/Gradle/Maven); Quick Start now references it before the first runnable example

## Changes

- `README.md` — four targeted edits, no other files changed

## Testing

- All import paths verified against `src/main/java/org/galaxio/gatling/javaapi/JdbcDsl.java`
- Gatling version verified against `project/Dependencies.scala` (3.13.5)
- DockerTest absence confirmed by grep across `src/`
- Testcontainers usage confirmed in `PostgreSQLIntegrationSpec.scala`

Fixes galax-io/gatling-jdbc-plugin#23, galax-io/gatling-jdbc-plugin#30, galax-io/gatling-jdbc-plugin#31, galax-io/gatling-jdbc-plugin#32