### PR TITLE
fix(protocol): bounded thread pool and proper JDBC resource cleanup

### DIFF
--- a/src/main/java/org/galaxio/gatling/javaapi/protocol/JdbcProtocolBuilderConnectionSettingsStep.java
+++ b/src/main/java/org/galaxio/gatling/javaapi/protocol/JdbcProtocolBuilderConnectionSettingsStep.java
@@ -15,15 +15,15 @@ public class JdbcProtocolBuilderConnectionSettingsStep {
         return new JdbcProtocolBuilder(wrapped.protocolBuilder());
     }
 
-    public JdbcProtocolBuilderConnectionSettingsStep maximumPoolSize(Integer newValue){
+    public JdbcProtocolBuilderConnectionSettingsStep maximumPoolSize(int newValue){
         return new JdbcProtocolBuilderConnectionSettingsStep(wrapped.maximumPoolSize(newValue));
     }
 
-    public JdbcProtocolBuilderConnectionSettingsStep minimumIdleConnections(Integer newValue){
+    public JdbcProtocolBuilderConnectionSettingsStep minimumIdleConnections(int newValue){
         return new JdbcProtocolBuilderConnectionSettingsStep(wrapped.minimumIdleConnections(newValue));
     }
 
-    public JdbcProtocolBuilderConnectionSettingsStep blockingPoolSize(Integer newValue){
+    public JdbcProtocolBuilderConnectionSettingsStep blockingPoolSize(int newValue){
         return new JdbcProtocolBuilderConnectionSettingsStep(wrapped.blockingPoolSize(newValue));
     }
 

--- a/src/main/scala/org/galaxio/gatling/jdbc/db/JDBCClient.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/db/JDBCClient.scala
@@ -5,7 +5,7 @@ import JDBCClient.Interpolator
 import statements._
 import statements.{CallableStatementWrapper, PreparedStatementWrapper, StatementWrapper}
 
-import java.util.concurrent.ExecutorService
+import java.util.concurrent.{ExecutorService, TimeUnit}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.util.{Failure, Success}
@@ -189,5 +189,6 @@ class JDBCClient(pool: HikariDataSource, blockingPool: ExecutorService, queryTim
   def close(): Unit = {
     pool.close()
     blockingPool.shutdown()
+    blockingPool.awaitTermination(30, TimeUnit.SECONDS)
   }
 }

--- a/src/main/scala/org/galaxio/gatling/jdbc/protocol/JdbcProtocol.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/protocol/JdbcProtocol.scala
@@ -41,7 +41,7 @@ object JdbcProtocol {
 
 }
 
-case class JdbcProtocol(hikariConfig: HikariConfig, blockingPoolSize: Int, queryTimeout: Option[FiniteDuration] = None)
+case class JdbcProtocol(hikariConfig: HikariConfig, private[protocol] val blockingPoolSize: Int, queryTimeout: Option[FiniteDuration] = None)
     extends Protocol {
   type Components = JdbcComponents
 }

--- a/src/main/scala/org/galaxio/gatling/jdbc/protocol/JdbcProtocol.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/protocol/JdbcProtocol.scala
@@ -41,7 +41,10 @@ object JdbcProtocol {
 
 }
 
-case class JdbcProtocol(hikariConfig: HikariConfig, private[protocol] val blockingPoolSize: Int, queryTimeout: Option[FiniteDuration] = None)
-    extends Protocol {
+case class JdbcProtocol(
+    hikariConfig: HikariConfig,
+    private[protocol] val blockingPoolSize: Int,
+    queryTimeout: Option[FiniteDuration] = None,
+) extends Protocol {
   type Components = JdbcComponents
 }

--- a/src/main/scala/org/galaxio/gatling/jdbc/protocol/JdbcProtocolBuilder.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/protocol/JdbcProtocolBuilder.scala
@@ -70,7 +70,7 @@ final case class JdbcProtocolBuilderConnectionSettingsStep(
 
 final case class JdbcProtocolBuilder(
     hikariConfig: HikariConfig,
-    blockingPoolSize: Int,
+    private[protocol] val blockingPoolSize: Int,
     queryTimeout: Option[FiniteDuration] = None,
 ) {
 

--- a/src/test/scala/org/galaxio/gatling/jdbc/db/JDBCClientThreadingSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/db/JDBCClientThreadingSpec.scala
@@ -71,7 +71,7 @@ class JDBCClientThreadingSpec extends AnyFlatSpec with Matchers {
 
     override def getConnection: Connection = {
       startedConnections.countDown()
-      releaseConnections.await(5, TimeUnit.SECONDS)
+      require(releaseConnections.await(5, TimeUnit.SECONDS), "releaseConnections latch timed out")
       connection
     }
 


### PR DESCRIPTION
## Summary

- Replace `newCachedThreadPool()` with `newFixedThreadPool(blockingPoolSize)` — prevents unbounded thread creation under JDBC load
- Add `blockingPoolSize` DSL option (defaults to `maximumPoolSize`) for Java and Scala APIs
- Move datasource shutdown from `ProtocolComponents.onExit` (fires per virtual user) to `actorSystem.registerOnTermination` (fires once at simulation end) — eliminates race condition where first VU exit closed shared pool mid-run

## Test plan

- [ ] `JDBCClientThreadingSpec` — thread count capped under concurrent blocked JDBC calls
- [ ] `JdbcProtocolBuilderSpec` — `blockingPoolSize` builder option
- [ ] Run full test suite: `sbt scalafmtCheckAll scalafmtSbtCheck compile test`

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)