### PR TITLE
refactor: dedup action failure handling, prune dead code, narrow db traits

### DIFF
--- a/src/main/scala/org/galaxio/gatling/jdbc/actions/ActionBase.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/actions/ActionBase.scala
@@ -1,17 +1,37 @@
 package org.galaxio.gatling.jdbc.actions
 
-import io.gatling.commons.stats.Status
-import io.gatling.core.action.Action
-import io.gatling.core.session.Session
+import io.gatling.commons.stats.{KO, Status}
+import io.gatling.commons.validation._
+import io.gatling.core.action.{Action, ChainableAction}
+import io.gatling.core.session.{Expression, Session}
 import io.gatling.core.structure.ScenarioContext
 import org.galaxio.gatling.jdbc.db.JDBCClient
 import org.galaxio.gatling.jdbc.protocol.JdbcProtocol
 
-trait ActionBase {
+trait ActionBase { self: ChainableAction =>
   val ctx: ScenarioContext
 
   private val jdbcComponents         = ctx.protocolComponentsRegistry.components(JdbcProtocol.jdbcProtocolKey)
   protected val dbClient: JDBCClient = jdbcComponents.client
+
+  protected def now: Long = ctx.coreComponents.clock.nowMillis
+
+  protected def resolveParams(session: Session, params: Seq[(String, Expression[Any])]): Validation[Map[String, Any]] =
+    params.foldLeft(Map.empty[String, Any].success) { case (r, (k, v)) =>
+      r.flatMap(m => v(session).map(rv => m + (k -> rv)))
+    }
+
+  /** KO callback for a failed JDBC execution: mark the session failed and log the response. */
+  protected def reportError(session: Session, startTime: Long, requestName: String, exception: Throwable): Unit =
+    executeNext(session.markAsFailed, startTime, now, KO, next, requestName, Some("ERROR"), Some(exception.getMessage))
+
+  /** Validation crash handler: log a request crash and emit a KO response for the unresolved request. */
+  protected def crashOnFailure(session: Session, requestName: Expression[String]): String => Unit =
+    message =>
+      requestName(session).map { rn =>
+        ctx.coreComponents.statsEngine.logRequestCrash(session.scenario, session.groups, rn, message)
+        executeNext(session.markAsFailed, now, now, KO, next, rn, Some("ERROR"), Some(message))
+      }
 
   protected def executeNext(
       session: Session,

--- a/src/main/scala/org/galaxio/gatling/jdbc/actions/DBBatchAction.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/actions/DBBatchAction.scala
@@ -1,6 +1,6 @@
 package org.galaxio.gatling.jdbc.actions
 
-import io.gatling.commons.stats.{KO, OK}
+import io.gatling.commons.stats.OK
 import io.gatling.commons.validation._
 import io.gatling.core.action.{Action, ChainableAction}
 import io.gatling.core.session.{Expression, Session}
@@ -23,9 +23,6 @@ final case class DBBatchAction(
   }
 
   override def name: String = genName("jdbcBatchAction")
-
-  private def resolveParams(session: Session, values: Seq[(String, Expression[Any])]): Validation[Map[String, Any]] =
-    values.traverse { case (k, v) => v(session).map((k, _)) }.map(_.toMap)
 
   private def resolveBatchAction(session: Session): PartialFunction[BatchAction, Validation[SqlWithParam]] = {
 
@@ -63,37 +60,13 @@ final case class DBBatchAction(
     (for {
       resolvedBatchName    <- batchName(session)
       sqlQueriesWithParams <- actions.traverse(resolveBatchAction(session))
-      startTime            <- ctx.coreComponents.clock.nowMillis.success
+      startTime            <- now.success
     } yield dbClient
       .batch(sqlQueriesWithParams)(
-        _ => executeNext(session, startTime, ctx.coreComponents.clock.nowMillis, OK, next, resolvedBatchName, None, None),
-        e =>
-          executeNext(
-            session.markAsFailed,
-            startTime,
-            ctx.coreComponents.clock.nowMillis,
-            KO,
-            next,
-            resolvedBatchName,
-            Some("ERROR"),
-            Some(e.getMessage),
-          ),
+        _ => executeNext(session, startTime, now, OK, next, resolvedBatchName, None, None),
+        e => reportError(session, startTime, resolvedBatchName, e),
       ))
-      .onFailure(m =>
-        batchName(session).map { rn =>
-          ctx.coreComponents.statsEngine.logRequestCrash(session.scenario, session.groups, rn, m)
-          executeNext(
-            session.markAsFailed,
-            ctx.coreComponents.clock.nowMillis,
-            ctx.coreComponents.clock.nowMillis,
-            KO,
-            next,
-            rn,
-            Some("ERROR"),
-            Some(m),
-          )
-        },
-      )
+      .onFailure(crashOnFailure(session, batchName))
   }
 
   override def statsEngine: StatsEngine = ctx.coreComponents.statsEngine

--- a/src/main/scala/org/galaxio/gatling/jdbc/actions/DBCallAction.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/actions/DBCallAction.scala
@@ -1,6 +1,6 @@
 package org.galaxio.gatling.jdbc.actions
 
-import io.gatling.commons.stats.{KO, OK}
+import io.gatling.commons.stats.OK
 import io.gatling.commons.validation._
 import io.gatling.core.action.{Action, ChainableAction}
 import io.gatling.core.session.{Expression, Session}
@@ -39,7 +39,7 @@ case class DBCallAction(
                      .withParamsMap(pParams.toMap)
                      .withOutParams(outParams)
                      .success
-      startTime <- ctx.coreComponents.clock.nowMillis.success
+      startTime <- now.success
 
     } yield dbClient
       .call(sql.sql, sql.params, sql.outParams)(
@@ -47,35 +47,11 @@ case class DBCallAction(
           // Surface each OUT parameter value into the Gatling session under its parameter name so that
           // downstream actions and checks can reference them via session attributes (e.g. "#{outParamName}").
           val updatedSession = outValues.foldLeft(session) { case (s, (name, value)) => s.set(name, value) }
-          executeNext(updatedSession, startTime, ctx.coreComponents.clock.nowMillis, OK, next, rn, None, None)
+          executeNext(updatedSession, startTime, now, OK, next, rn, None, None)
         },
-        e =>
-          executeNext(
-            session.markAsFailed,
-            startTime,
-            ctx.coreComponents.clock.nowMillis,
-            KO,
-            next,
-            rn,
-            Some("ERROR"),
-            Some(e.getMessage),
-          ),
+        e => reportError(session, startTime, rn, e),
       ))
-      .onFailure(m =>
-        requestName(session).map { rn =>
-          ctx.coreComponents.statsEngine.logRequestCrash(session.scenario, session.groups, rn, m)
-          executeNext(
-            session.markAsFailed,
-            ctx.coreComponents.clock.nowMillis,
-            ctx.coreComponents.clock.nowMillis,
-            KO,
-            next,
-            rn,
-            Some("ERROR"),
-            Some(m),
-          )
-        },
-      )
+      .onFailure(crashOnFailure(session, requestName))
 
   override def statsEngine: StatsEngine = ctx.coreComponents.statsEngine
 }

--- a/src/main/scala/org/galaxio/gatling/jdbc/actions/DBInsertAction.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/actions/DBInsertAction.scala
@@ -1,6 +1,6 @@
 package org.galaxio.gatling.jdbc.actions
 
-import io.gatling.commons.stats.{KO, OK}
+import io.gatling.commons.stats.OK
 import io.gatling.commons.validation._
 import io.gatling.core.action.{Action, ChainableAction}
 import io.gatling.core.session.{Expression, Session}
@@ -23,45 +23,18 @@ case class DBInsertAction(
     (for {
       rn        <- requestName(session)
       tName     <- tableName(session)
-      iParams   <- sessionValues
-                     .foldLeft(Map[String, Any]().success) { case (r, (k, v)) =>
-                       r.flatMap(m => v(session).map(rv => m + (k -> rv)))
-                     }
+      iParams   <- resolveParams(session, sessionValues)
       sql       <- SQL(s"INSERT INTO $tName (${columns.mkString(",")}) VALUES(${columns.map(s => s"{$s}").mkString(",")})")
                      .withParamsMap(iParams)
                      .success
-      startTime <- ctx.coreComponents.clock.nowMillis.success
+      startTime <- now.success
 
     } yield dbClient
       .executeUpdate(sql.sql, sql.params)(
-        _ => executeNext(session, startTime, ctx.coreComponents.clock.nowMillis, OK, next, rn, None, None),
-        e =>
-          executeNext(
-            session.markAsFailed,
-            startTime,
-            ctx.coreComponents.clock.nowMillis,
-            KO,
-            next,
-            rn,
-            Some("ERROR"),
-            Some(e.getMessage),
-          ),
+        _ => executeNext(session, startTime, now, OK, next, rn, None, None),
+        e => reportError(session, startTime, rn, e),
       ))
-      .onFailure(m =>
-        requestName(session).map { rn =>
-          ctx.coreComponents.statsEngine.logRequestCrash(session.scenario, session.groups, rn, m)
-          executeNext(
-            session.markAsFailed,
-            ctx.coreComponents.clock.nowMillis,
-            ctx.coreComponents.clock.nowMillis,
-            KO,
-            next,
-            rn,
-            Some("ERROR"),
-            Some(m),
-          )
-        },
-      )
+      .onFailure(crashOnFailure(session, requestName))
 
   override def statsEngine: StatsEngine = ctx.coreComponents.statsEngine
 }

--- a/src/main/scala/org/galaxio/gatling/jdbc/actions/DBQueryAction.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/actions/DBQueryAction.scala
@@ -24,24 +24,18 @@ case class DBQueryAction(
 
   override def name: String = genName("jdbcQueryAction")
 
-  private def resolveParams(session: Session) =
-    params
-      .foldLeft(Map[String, Any]().success) { case (r, (k, v)) =>
-        r.flatMap(m => v(session).map(rv => m + (k -> rv)))
-      }
-
   override def execute(session: Session): Unit =
     (for {
       resolvedName    <- requestName(session)
       resolvedQuery   <- sql(session)
-      resolvedParams  <- resolveParams(session)
+      resolvedParams  <- resolveParams(session, params)
       parametrisedSql <- SQL(resolvedQuery).withParamsMap(resolvedParams).success
-      startTime       <- ctx.coreComponents.clock.nowMillis.success
+      startTime       <- now.success
 
     } yield dbClient
       .executeSelect(parametrisedSql.sql, parametrisedSql.params)(
         value => {
-          val received            = ctx.coreComponents.clock.nowMillis
+          val received            = now
           val (newSession, error) = Check.check(value, session, checks.toList, new JHashMap[Any, Any]())
 
           error match {
@@ -59,33 +53,9 @@ case class DBQueryAction(
             case _                            => executeNext(newSession, startTime, received, OK, next, resolvedName, None, None)
           }
         },
-        exception =>
-          executeNext(
-            session.markAsFailed,
-            startTime,
-            ctx.coreComponents.clock.nowMillis,
-            KO,
-            next,
-            resolvedName,
-            Some("ERROR"),
-            Some(exception.getMessage),
-          ),
+        exception => reportError(session, startTime, resolvedName, exception),
       ))
-      .onFailure(m =>
-        requestName(session).map { rn =>
-          ctx.coreComponents.statsEngine.logRequestCrash(session.scenario, session.groups, rn, m)
-          executeNext(
-            session.markAsFailed,
-            ctx.coreComponents.clock.nowMillis,
-            ctx.coreComponents.clock.nowMillis,
-            KO,
-            next,
-            rn,
-            Some("ERROR"),
-            Some(m),
-          )
-        },
-      )
+      .onFailure(crashOnFailure(session, requestName))
 
   override def statsEngine: StatsEngine = ctx.coreComponents.statsEngine
 }

--- a/src/main/scala/org/galaxio/gatling/jdbc/actions/DBRawQueryAction.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/actions/DBRawQueryAction.scala
@@ -1,6 +1,6 @@
 package org.galaxio.gatling.jdbc.actions
 
-import io.gatling.commons.stats.{KO, OK}
+import io.gatling.commons.stats.OK
 import io.gatling.commons.validation._
 import io.gatling.core.action.{Action, ChainableAction}
 import io.gatling.core.session.{Expression, Session}
@@ -18,38 +18,14 @@ case class DBRawQueryAction(requestName: Expression[String], query: Expression[S
       resolvedName  <- requestName(session)
       resolvedQuery <- query(session)
       sql           <- SQL(resolvedQuery).success
-      startTime     <- ctx.coreComponents.clock.nowMillis.success
+      startTime     <- now.success
 
     } yield dbClient
       .executeRaw(sql.q)(
-        _ => executeNext(session, startTime, ctx.coreComponents.clock.nowMillis, OK, next, resolvedName, None, None),
-        exception =>
-          executeNext(
-            session.markAsFailed,
-            startTime,
-            ctx.coreComponents.clock.nowMillis,
-            KO,
-            next,
-            resolvedName,
-            Some("ERROR"),
-            Some(exception.getMessage),
-          ),
+        _ => executeNext(session, startTime, now, OK, next, resolvedName, None, None),
+        exception => reportError(session, startTime, resolvedName, exception),
       ))
-      .onFailure(m =>
-        requestName(session).map { rn =>
-          ctx.coreComponents.statsEngine.logRequestCrash(session.scenario, session.groups, rn, m)
-          executeNext(
-            session.markAsFailed,
-            ctx.coreComponents.clock.nowMillis,
-            ctx.coreComponents.clock.nowMillis,
-            KO,
-            next,
-            rn,
-            Some("ERROR"),
-            Some(m),
-          )
-        },
-      )
+      .onFailure(crashOnFailure(session, requestName))
 
   override def statsEngine: StatsEngine = ctx.coreComponents.statsEngine
 }

--- a/src/main/scala/org/galaxio/gatling/jdbc/db/package.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/db/package.scala
@@ -36,31 +36,6 @@ package object db {
   }
 
   case class SqlWithParam(sql: String, params: Seq[(String, ParamVal)], outParams: Seq[(String, Int)] = Seq.empty) {
-    private val paramsMap                     = params.toMap
-    private def paramValueToSql(name: String) =
-      paramsMap.get(name) match {
-        case Some(IntParam(v))     => s"$v"
-        case Some(DoubleParam(v))  => s"$v"
-        case Some(StrParam(v))     => s"'$v'"
-        case Some(LongParam(v))    => s"$v"
-        case Some(NullParam)       => "NULL"
-        case Some(DateParam(v))    => s"CAST('$v' AS TIMESTAMP)"
-        case Some(UUIDParam(v))    => s"CAST('$v' AS UUID)"
-        case Some(BooleanParam(v)) => s"$v"
-        case None                  => ""
-      }
-
-    def substituteParams: String = {
-      sql
-        .foldLeft(("", "", false)) {
-          case ((r, curName, false), '{') => (r, curName, true)
-          case ((r, curName, true), '}')  => (s"$r ${paramValueToSql(curName.trim)}", "", false)
-          case ((r, curName, true), c)    => (r, s"$curName$c", true)
-          case ((r, curName, false), c)   => (s"$r$c", curName, false)
-        }
-        ._1
-    }
-
     def withOutParams(ps: Seq[(String, Int)]): SqlWithParam = SqlWithParam(sql, params, ps)
   }
 

--- a/src/main/scala/org/galaxio/gatling/jdbc/db/statements.scala
+++ b/src/main/scala/org/galaxio/gatling/jdbc/db/statements.scala
@@ -10,8 +10,6 @@ object statements {
   trait StatementWrapper[F[_]] {
     def execute(sql: String): F[Boolean]
     def close: F[Unit]
-    def addBatch(sql: String): F[Unit]
-    def executeBatch: F[Array[Int]]
   }
 
   trait PreparedStatementWrapper[F[_]] {
@@ -20,27 +18,12 @@ object statements {
     def executeUpdate: F[Int]
     def addBatch: F[Unit]
     def executeBatch: F[Array[Int]]
-    def setInt(index: Int, value: Int): F[Unit]
-    def setDouble(index: Int, value: Double): F[Unit]
-    def setString(index: Int, value: String): F[Unit]
-    def setLong(index: Int, value: Long): F[Unit]
-    def setObject(index: Int, value: Object): F[Unit]
-    def setBoolean(index: Int, value: Boolean): F[Unit]
-    def setTimestamp(index: Int, value: java.sql.Timestamp): F[Unit]
     def setParams(interpolated: InterpolatorCtx, params: Map[String, ParamVal]): F[Unit]
   }
 
   trait CallableStatementWrapper[F[_]] {
     def close: F[Unit]
     def executeUpdate: F[Int]
-    def setInt(index: Int, value: Int): F[Unit]
-    def setDouble(index: Int, value: Double): F[Unit]
-    def setString(index: Int, value: String): F[Unit]
-    def setLong(index: Int, value: Long): F[Unit]
-    def setBoolean(index: Int, value: Boolean): F[Unit]
-    def setObject(index: Int, value: Object): F[Unit]
-    def setTimestamp(index: Int, value: java.sql.Timestamp): F[Unit]
-    def registerOutParameter(index: Int, sqlType: Int): F[Unit]
     def setParams(interpolated: InterpolatorCtx, inParams: Map[String, ParamVal], outParams: Map[String, Int]): Future[Unit]
 
     /** Read all registered OUT parameters after execution.
@@ -60,10 +43,6 @@ object statements {
     override def execute(sql: String): Future[Boolean] = Future(stmt.execute(sql))
 
     override def close: Future[Unit] = Future(stmt.close())
-
-    override def addBatch(sql: String): Future[Unit] = Future(stmt.addBatch(sql))
-
-    override def executeBatch: Future[Array[Int]] = Future(stmt.executeBatch())
   }
 
   private final class PreparedStatementWrapperImpl(stmt: PreparedStatement, queryTimeoutSeconds: Option[Int])(implicit
@@ -80,19 +59,19 @@ object statements {
 
     override def executeBatch: Future[Array[Int]] = Future(stmt.executeBatch())
 
-    override def setDouble(index: Int, value: Double): Future[Unit] = Future(stmt.setDouble(index, value))
+    private def setDouble(index: Int, value: Double): Future[Unit] = Future(stmt.setDouble(index, value))
 
-    override def setString(index: Int, value: String): Future[Unit] = Future(stmt.setString(index, value))
+    private def setString(index: Int, value: String): Future[Unit] = Future(stmt.setString(index, value))
 
-    override def setLong(index: Int, value: Long): Future[Unit] = Future(stmt.setLong(index, value))
+    private def setLong(index: Int, value: Long): Future[Unit] = Future(stmt.setLong(index, value))
 
-    override def setObject(index: Int, value: Object): Future[Unit] = Future(stmt.setObject(index, value))
+    private def setObject(index: Int, value: Object): Future[Unit] = Future(stmt.setObject(index, value))
 
-    override def setTimestamp(index: Int, value: Timestamp): Future[Unit] = Future(stmt.setTimestamp(index, value))
+    private def setTimestamp(index: Int, value: Timestamp): Future[Unit] = Future(stmt.setTimestamp(index, value))
 
-    override def setInt(index: Int, value: Int): Future[Unit] = Future(stmt.setInt(index, value))
+    private def setInt(index: Int, value: Int): Future[Unit] = Future(stmt.setInt(index, value))
 
-    override def setBoolean(index: Int, value: Boolean): Future[Unit] = Future(stmt.setBoolean(index, value))
+    private def setBoolean(index: Int, value: Boolean): Future[Unit] = Future(stmt.setBoolean(index, value))
 
     override def setParams(interpolated: InterpolatorCtx, params: Map[String, ParamVal]): Future[Unit] = {
       if (params.isEmpty)
@@ -121,19 +100,19 @@ object statements {
 
     override def executeUpdate: Future[Int] = Future(stmt.executeUpdate())
 
-    override def setDouble(index: Int, value: Double): Future[Unit] = Future(stmt.setDouble(index, value))
+    private def setDouble(index: Int, value: Double): Future[Unit] = Future(stmt.setDouble(index, value))
 
-    override def setString(index: Int, value: String): Future[Unit] = Future(stmt.setString(index, value))
+    private def setString(index: Int, value: String): Future[Unit] = Future(stmt.setString(index, value))
 
-    override def setLong(index: Int, value: Long): Future[Unit] = Future(stmt.setLong(index, value))
+    private def setLong(index: Int, value: Long): Future[Unit] = Future(stmt.setLong(index, value))
 
-    override def setObject(index: Int, value: Object): Future[Unit] = Future(stmt.setObject(index, value))
+    private def setObject(index: Int, value: Object): Future[Unit] = Future(stmt.setObject(index, value))
 
-    override def setTimestamp(index: Int, value: Timestamp): Future[Unit] = Future(stmt.setTimestamp(index, value))
+    private def setTimestamp(index: Int, value: Timestamp): Future[Unit] = Future(stmt.setTimestamp(index, value))
 
-    override def setInt(index: Int, value: Int): Future[Unit] = Future(stmt.setInt(index, value))
+    private def setInt(index: Int, value: Int): Future[Unit] = Future(stmt.setInt(index, value))
 
-    override def registerOutParameter(index: Int, sqlType: Int): Future[Unit] =
+    private def registerOutParameter(index: Int, sqlType: Int): Future[Unit] =
       Future(stmt.registerOutParameter(index, sqlType))
 
     override def setParams(
@@ -169,7 +148,7 @@ object statements {
         }.reduce((f1, f2) => f1.flatMap(_ => f2))
     }
 
-    override def setBoolean(index: Int, value: Boolean): Future[Unit] = Future(stmt.setBoolean(index, value))
+    private def setBoolean(index: Int, value: Boolean): Future[Unit] = Future(stmt.setBoolean(index, value))
 
     override def getOutParams(outParams: Map[String, List[Int]]): Future[Map[String, Any]] =
       Future(outParams.map { case (name, indexes) =>

--- a/src/test/scala/org/galaxio/gatling/jdbc/db/SqlWithParamSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/db/SqlWithParamSpec.scala
@@ -6,15 +6,12 @@ import org.scalatest.matchers.should.Matchers
 import java.time.LocalDateTime
 import java.util.UUID
 
-/** Unit-level regression tests for SQL interpolation and parameter mapping.
+/** Unit-level regression tests for SQL parameter mapping.
   *
-  * Covers `SQL.withParamsMap` type-coercion logic and `SqlWithParam.substituteParams` string-rendering for every `ParamVal`
-  * variant. These tests require no database — all assertions are over pure in-memory data structures.
+  * Covers `SQL.withParamsMap` type-coercion logic for every `ParamVal` variant. These tests require no database — all
+  * assertions are over pure in-memory data structures.
   *
-  * Protects against regressions in:
-  *   - type-dispatch in `withParamsMap` (wrong ParamVal produced for a Scala type)
-  *   - SQL-rendering in `paramValueToSql` (wrong SQL fragment for a ParamVal variant)
-  *   - placeholder parsing in `substituteParams` (brace delimiters, whitespace trimming)
+  * Protects against regressions in type-dispatch in `withParamsMap` (wrong ParamVal produced for a Scala type).
   */
 class SqlWithParamSpec extends AnyFlatSpec with Matchers {
 
@@ -83,71 +80,6 @@ class SqlWithParamSpec extends AnyFlatSpec with Matchers {
     )
   }
 
-  // ─── substituteParams SQL rendering ──────────────────────────────────────────
-
-  "SqlWithParam.substituteParams" should "render IntParam as a bare integer literal" in {
-    val result = SQL("SELECT {n}").withParamsMap(Map("n" -> 42)).substituteParams
-    result.trim shouldBe "SELECT  42"
-  }
-
-  it should "render LongParam as a bare long literal" in {
-    val result = SQL("SELECT {n}").withParamsMap(Map("n" -> 100L)).substituteParams
-    result.trim shouldBe "SELECT  100"
-  }
-
-  it should "render DoubleParam as a bare double literal" in {
-    val result = SQL("WHERE v > {v}").withParamsMap(Map("v" -> 1.5)).substituteParams
-    result.trim shouldBe "WHERE v >  1.5"
-  }
-
-  it should "render StrParam wrapped in single quotes" in {
-    val result = SQL("WHERE name = {name}").withParamsMap(Map("name" -> "alice")).substituteParams
-    result.trim shouldBe "WHERE name =  'alice'"
-  }
-
-  it should "render NullParam as the keyword NULL" in {
-    val result = SQL("WHERE x = {x}").withParamsMap(Map("x" -> null)).substituteParams
-    result.trim shouldBe "WHERE x =  NULL"
-  }
-
-  it should "render BooleanParam as a bare boolean literal" in {
-    val resultTrue  = SQL("{f}").withParamsMap(Map("f" -> true)).substituteParams.trim
-    val resultFalse = SQL("{f}").withParamsMap(Map("f" -> false)).substituteParams.trim
-    resultTrue shouldBe "true"
-    resultFalse shouldBe "false"
-  }
-
-  it should "render DateParam as a CAST TIMESTAMP expression" in {
-    val dt     = LocalDateTime.of(2024, 6, 1, 12, 0, 0)
-    val result = SQL("WHERE ts = {ts}").withParamsMap(Map("ts" -> dt)).substituteParams
-    result should include("CAST(")
-    result should include("AS TIMESTAMP)")
-    result should include("2024-06-01")
-  }
-
-  it should "render UUIDParam as a CAST UUID expression" in {
-    val id     = UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
-    val result = SQL("WHERE id = {id}").withParamsMap(Map("id" -> id)).substituteParams
-    result should include("CAST(")
-    result should include("AS UUID)")
-    result should include(id.toString)
-  }
-
-  it should "render an empty string for an unknown placeholder name" in {
-    // A placeholder that has no matching param key renders as an empty string fragment
-    val sql    = SqlWithParam("SELECT {missing}", params = Seq.empty)
-    val result = sql.substituteParams
-    result should not include "{missing}"
-  }
-
-  it should "substitute multiple placeholders in a single query" in {
-    val result = SQL("INSERT INTO t (a,b) VALUES ({a},{b})")
-      .withParamsMap(Map("a" -> 1, "b" -> "two"))
-      .substituteParams
-    result should include("1")
-    result should include("'two'")
-  }
-
   // ─── withParams (explicit ParamVal binding) ───────────────────────────────────
 
   "SQL.withParams" should "preserve explicitly provided ParamVal values unchanged" in {
@@ -158,7 +90,6 @@ class SqlWithParamSpec extends AnyFlatSpec with Matchers {
   it should "allow explicit NullParam without using the 'NULL' sentinel string" in {
     val swp = SQL("SELECT {x}").withParams("x" -> NullParam)
     swp.params should contain("x" -> NullParam)
-    swp.substituteParams should include("NULL")
   }
 
   // ─── withOutParams ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Repository audit cleanup. **Net −227 lines, behavior preserved, all 83 tests pass.**

### Consolidation (duplication → ActionBase)
The 5 DB actions (`DBQuery`, `DBRawQuery`, `DBInsert`, `DBCall`, `DBBatch`) each repeated the same ~15-line blocks. Extracted into `ActionBase`:
- `now` — clock access
- `reportError(session, startTime, requestName, exception)` — KO callback for failed JDBC execution
- `crashOnFailure(session, requestName)` — validation crash handler (logRequestCrash + KO)
- `resolveParams(session, params)` — the `Expression[Any]` → `Map[String, Any]` fold (was copy-pasted 3×)

### Dead code removed
- `StatementWrapper.addBatch`/`executeBatch` — the batch path uses `PreparedStatementWrapper`; these were never called.
- `SqlWithParam.substituteParams` + `paramValueToSql` — replaced by prepared statements in the SQL-injection fix (#38). Only its own tests kept it alive, and it's a raw-value string interpolator (injection-shaped). Removed it and its 11 tests.

### Trait narrowing
- Removed `setInt`/`setDouble`/`setString`/`setLong`/`setObject`/`setBoolean`/`setTimestamp`/`registerOutParameter` from the `PreparedStatementWrapper` and `CallableStatementWrapper` public traits — they're only used inside each Impl's `setParams`, now `private`.

## Test plan
- [x] `sbt scalafmtCheckAll scalafmtSbtCheck compile test` — 83/83 pass
- [x] Failure-path behavior covered by `ActionSessionFailureSpec`, `SessionMarkAsFailedSpec`, `JDBCClientFailureCallbackSpec`

## Not included (flagged for follow-up)
- The `F[_]` tagless abstraction on the `*Wrapper` traits has a single `Future` implementation — collapsing it would remove real indirection, but it's a larger change deferred for separate review.
- `JdbcDsl.insetInto` (deprecated typo alias) is public API — removal is a breaking change, recommend dropping in the next major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)