### PR TITLE
chore: gitignore Metals/Bloop artifacts and generated .mcp.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@
 /target/
 /results/
 .DS_Store
+
+### Metals / Bloop
+.mcp.json
+/.metals/
+/.bloop/
+/project/metals.sbt
+/project/.bloop/


### PR DESCRIPTION
## Summary
- Metals (Scala LSP) auto-generates local artifacts on build import: `.mcp.json` (pointer to its local MCP server with an ephemeral port), `.metals/`, `.bloop/`, `project/metals.sbt`, `project/.bloop/`.
- None of these belong in version control — the port changes on every Metals restart and the rest is per-machine tooling state.
- Added a Metals/Bloop section to `.gitignore` covering all of them.

## Verification
- `git status` clean after the change: all Metals-generated files disappeared from untracked.
- `.gitignore`-only diff; no Scala/sbt sources touched. Note: `sbt scalafmtCheckAll` could not run in a linked git worktree (sbt-git/JGit fails to load the project there: "Bare Repository has neither a working tree"), but the diff contains no formattable sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)