### PR TITLE
ci(milestones): enforce current-milestone assignment via milestone-guard hook

### DIFF
--- a/.claude/hooks/milestone-guard.sh
+++ b/.claude/hooks/milestone-guard.sh
@@ -1,96 +1,31 @@
 #!/usr/bin/env bash
-#
-# milestone-guard.sh — PreToolUse(Bash) hook.
-# Milestone *assignments* of an issue/PR must target the CURRENT release milestone
-# (the single open `vX.Y.0 …` milestone). Blocks scattering work into thematic or
-# other-version milestones. Read-only `gh` calls and any command without a milestone
-# assignment pass untouched with no network call (~0 tokens).
-#
-# "Current" = lowest-semver OPEN milestone whose title starts with `vX.Y.0`
-# (same definition check-linkage.sh uses). Keep it in sync with that script.
-#
-# Bypass a deliberate backlog/deferral move by prefixing the command:
-#   MILESTONE_GUARD_OFF=1 gh issue edit 42 --milestone "1d — …"
+# PreToolUse(Bash): an issue/PR milestone may only be the current vX.Y.0 release
+# milestone. Fires ONLY on a real gh assignment command (not text that mentions one);
+# reads and everything else pass. Bypass a backlog move: MILESTONE_GUARD_OFF=1 <cmd>
 set -uo pipefail
-
-input=$(cat)
-cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || true)
-[ -n "$cmd" ] || exit 0
-
-# Fast path: only gh commands that mention a milestone are ever in scope.
-case "$cmd" in *"gh "*) ;; *) exit 0 ;; esac
-case "$cmd" in *milestone*) ;; *) exit 0 ;; esac
-# Explicit opt-out for intentional off-milestone moves.
+cmd=$(jq -r '.tool_input.command // ""' 2>/dev/null) || exit 0
 case "$cmd" in *MILESTONE_GUARD_OFF=1*) exit 0 ;; esac
 
-block() { printf 'BLOCKED by milestone-guard:\n%s\n' "$1" >&2; exit 2; }
+# In scope only when gh actually assigns a milestone: `issue|pr edit|create --milestone`,
+# or `api … -F milestone=`. Anchored to the subcommand so a commit message or echo that
+# merely contains "--milestone" does not trigger it.
+is_assign=0
+{ printf '%s' "$cmd" | grep -qE '\bgh +(issue|pr) +(edit|create)\b' && printf '%s' "$cmd" | grep -qE -- '--milestone[= ]'; } && is_assign=1
+{ printf '%s' "$cmd" | grep -qE '\bgh +api\b'                       && printf '%s' "$cmd" | grep -qE -- '-[fF] +milestone='; } && is_assign=1
+[ "$is_assign" = 1 ] || exit 0
 
-# --- Is this a milestone *assignment* (a write), not a read/list? -------------
-is_write=0
-# gh issue|pr edit|create ... --milestone <x>
-if printf '%s' "$cmd" | grep -qE '\bgh[[:space:]]+(issue|pr)[[:space:]]+(edit|create)\b' \
-   && printf '%s' "$cmd" | grep -qE -- '--milestone(=|[[:space:]])'; then
-  is_write=1
-fi
-# gh api writing a milestone= field (-f/-F/--field/--raw-field milestone=…) or an
-# explicit write method carrying a milestone= param. Query strings (?/&milestone=)
-# are reads and never match the field-flag form.
-if printf '%s' "$cmd" | grep -qE '\bgh[[:space:]]+api\b'; then
-  if printf '%s' "$cmd" | grep -qE -- '(-f|-F|--field|--raw-field)[[:space:]]+milestone=' \
-     || { printf '%s' "$cmd" | grep -qE -- '(--method|-X)[[:space:]]+(PATCH|POST|PUT)' \
-          && printf '%s' "$cmd" | grep -qE 'milestone=' ; }; then
-    is_write=1
-  fi
-fi
-[ "$is_write" = 1 ] || exit 0
+val=$(printf '%s' "$cmd" | grep -oE -- '--milestone[= ]+("[^"]*"|[^ ]+)|-[fF] +milestone=[^ ]+' | head -1 \
+      | sed -E 's/^--milestone[= ]+//; s/^-[fF] +milestone=//; s/^"//; s/"$//')
+[ -n "$val" ] || exit 0   # clearing a milestone → fine
 
-# Clearing a milestone is never a scatter.
-printf '%s' "$cmd" | grep -qE -- '--remove-milestone' && exit 0
+cur=$(bash "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}/scripts/current-milestone.sh" 2>/dev/null || true)
+[ -n "$cur" ] || exit 0   # no current milestone to compare against → stay out of the way
+num=$(printf '%s' "$cur" | cut -f1)
+ver=$(printf '%s' "$cur" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
 
-# --- Extract the assigned milestone value -------------------------------------
-val=""
-# api field form: milestone=VALUE (a numeric id)
-val=$(printf '%s' "$cmd" | grep -oE 'milestone=[^ ]+' | head -1 | sed 's/^milestone=//')
-# --milestone=VALUE
-if [ -z "$val" ]; then
-  val=$(printf '%s' "$cmd" | grep -oE -- '--milestone=[^ ]+' | head -1 | sed 's/^--milestone=//')
-fi
-# --milestone VALUE  (quoted title, or a bare token)
-if [ -z "$val" ]; then
-  val=$(printf '%s' "$cmd" | sed -nE 's/.*--milestone[[:space:]]+"([^"]*)".*/\1/p' | head -1)
-  [ -z "$val" ] && val=$(printf '%s' "$cmd" | sed -nE "s/.*--milestone[[:space:]]+'([^']*)'.*/\1/p" | head -1)
-  [ -z "$val" ] && val=$(printf '%s' "$cmd" | sed -nE 's/.*--milestone[[:space:]]+([^ ]+).*/\1/p' | head -1)
-fi
-# strip a stray leading/trailing quote if one survived
-val=$(printf '%s' "$val" | sed -E 's/^["'"'"']//; s/["'"'"']$//')
-# Empty target = clearing the milestone; not a scatter.
-[ -n "$val" ] || exit 0
+# Pass if the target is the current number, or a title carrying the current version.
+[ "$val" = "$num" ] && exit 0
+[ -n "$ver" ] && printf '%s' "$val" | grep -qF "$ver" && exit 0
 
-# --- Resolve the current release milestone (shared resolver) ------------------
-root="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-resolver="$root/scripts/current-milestone.sh"
-[ -f "$resolver" ] || block "current-milestone resolver missing ($resolver) — cannot verify milestone; bypass with MILESTONE_GUARD_OFF=1"
-cur=$(bash "$resolver" 2>/dev/null) \
-  || block "cannot determine repo to verify milestone — set REPO=owner/name, or bypass with MILESTONE_GUARD_OFF=1"
-[ -n "$cur" ] || block "no open version milestone (vX.Y.0) to assign into — create the release milestone first, or bypass with MILESTONE_GUARD_OFF=1.
-  target: $val"
-
-cur_num=$(printf '%s' "$cur" | cut -f1)
-cur_title=$(printf '%s' "$cur" | cut -f2)
-cur_ver=$(printf '%s' "$cur_title" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-
-# --- Compare target to current ------------------------------------------------
-ok=0
-if printf '%s' "$val" | grep -qE '^[0-9]+$'; then
-  [ "$val" = "$cur_num" ] && ok=1                       # assigned by milestone number
-else
-  vtok=$(printf '%s' "$val" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
-  { [ -n "$vtok" ] && [ "$vtok" = "$cur_ver" ]; } && ok=1   # title carries the current version
-  [ "$val" = "$cur_title" ] && ok=1                    # exact title match
-fi
-[ "$ok" = 1 ] && exit 0
-
-block "issue/PR milestone must be the current release milestone.
-  current : #$cur_num  $cur_title
-  target  : $val
-Assign to #$cur_num (its number, title, or $cur_ver). To defer to the backlog on purpose, prefix: MILESTONE_GUARD_OFF=1 <cmd>"
+printf 'BLOCKED by milestone-guard: assign to the current milestone #%s (%s), not "%s".\nDeliberate backlog move? prefix MILESTONE_GUARD_OFF=1\n' "$num" "$ver" "$val" >&2
+exit 2

--- a/.claude/hooks/milestone-guard.sh
+++ b/.claude/hooks/milestone-guard.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# milestone-guard.sh — PreToolUse(Bash) hook.
+# Milestone *assignments* of an issue/PR must target the CURRENT release milestone
+# (the single open `vX.Y.0 …` milestone). Blocks scattering work into thematic or
+# other-version milestones. Read-only `gh` calls and any command without a milestone
+# assignment pass untouched with no network call (~0 tokens).
+#
+# "Current" = lowest-semver OPEN milestone whose title starts with `vX.Y.0`
+# (same definition check-linkage.sh uses). Keep it in sync with that script.
+#
+# Bypass a deliberate backlog/deferral move by prefixing the command:
+#   MILESTONE_GUARD_OFF=1 gh issue edit 42 --milestone "1d — …"
+set -uo pipefail
+
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || true)
+[ -n "$cmd" ] || exit 0
+
+# Fast path: only gh commands that mention a milestone are ever in scope.
+case "$cmd" in *"gh "*) ;; *) exit 0 ;; esac
+case "$cmd" in *milestone*) ;; *) exit 0 ;; esac
+# Explicit opt-out for intentional off-milestone moves.
+case "$cmd" in *MILESTONE_GUARD_OFF=1*) exit 0 ;; esac
+
+block() { printf 'BLOCKED by milestone-guard:\n%s\n' "$1" >&2; exit 2; }
+
+# --- Is this a milestone *assignment* (a write), not a read/list? -------------
+is_write=0
+# gh issue|pr edit|create ... --milestone <x>
+if printf '%s' "$cmd" | grep -qE '\bgh[[:space:]]+(issue|pr)[[:space:]]+(edit|create)\b' \
+   && printf '%s' "$cmd" | grep -qE -- '--milestone(=|[[:space:]])'; then
+  is_write=1
+fi
+# gh api writing a milestone= field (-f/-F/--field/--raw-field milestone=…) or an
+# explicit write method carrying a milestone= param. Query strings (?/&milestone=)
+# are reads and never match the field-flag form.
+if printf '%s' "$cmd" | grep -qE '\bgh[[:space:]]+api\b'; then
+  if printf '%s' "$cmd" | grep -qE -- '(-f|-F|--field|--raw-field)[[:space:]]+milestone=' \
+     || { printf '%s' "$cmd" | grep -qE -- '(--method|-X)[[:space:]]+(PATCH|POST|PUT)' \
+          && printf '%s' "$cmd" | grep -qE 'milestone=' ; }; then
+    is_write=1
+  fi
+fi
+[ "$is_write" = 1 ] || exit 0
+
+# Clearing a milestone is never a scatter.
+printf '%s' "$cmd" | grep -qE -- '--remove-milestone' && exit 0
+
+# --- Extract the assigned milestone value -------------------------------------
+val=""
+# api field form: milestone=VALUE (a numeric id)
+val=$(printf '%s' "$cmd" | grep -oE 'milestone=[^ ]+' | head -1 | sed 's/^milestone=//')
+# --milestone=VALUE
+if [ -z "$val" ]; then
+  val=$(printf '%s' "$cmd" | grep -oE -- '--milestone=[^ ]+' | head -1 | sed 's/^--milestone=//')
+fi
+# --milestone VALUE  (quoted title, or a bare token)
+if [ -z "$val" ]; then
+  val=$(printf '%s' "$cmd" | sed -nE 's/.*--milestone[[:space:]]+"([^"]*)".*/\1/p' | head -1)
+  [ -z "$val" ] && val=$(printf '%s' "$cmd" | sed -nE "s/.*--milestone[[:space:]]+'([^']*)'.*/\1/p" | head -1)
+  [ -z "$val" ] && val=$(printf '%s' "$cmd" | sed -nE 's/.*--milestone[[:space:]]+([^ ]+).*/\1/p' | head -1)
+fi
+# strip a stray leading/trailing quote if one survived
+val=$(printf '%s' "$val" | sed -E 's/^["'"'"']//; s/["'"'"']$//')
+# Empty target = clearing the milestone; not a scatter.
+[ -n "$val" ] || exit 0
+
+# --- Resolve the current release milestone ------------------------------------
+REPO="${REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)}"
+[ -n "$REPO" ] || block "cannot determine repo to verify milestone — set REPO=owner/name, or bypass with MILESTONE_GUARD_OFF=1"
+
+cur=$(gh api "repos/$REPO/milestones?state=open&per_page=100" --jq '
+  [ .[]
+    | select(.title | test("^v[0-9]+\\.[0-9]+\\.0"))
+    | . + { _k: ((.title | capture("^v(?<a>[0-9]+)\\.(?<b>[0-9]+)")) | (.a|tonumber) * 100000 + (.b|tonumber)) }
+  ]
+  | sort_by(._k) | .[0] // empty
+  | if . == "" then "" else "\(.number)\t\(.title)" end' 2>/dev/null || true)
+
+[ -n "$cur" ] || block "no open version milestone (vX.Y.0) to assign into — create the release milestone first, or bypass with MILESTONE_GUARD_OFF=1.
+  target: $val"
+
+cur_num=$(printf '%s' "$cur" | cut -f1)
+cur_title=$(printf '%s' "$cur" | cut -f2)
+cur_ver=$(printf '%s' "$cur_title" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+
+# --- Compare target to current ------------------------------------------------
+ok=0
+if printf '%s' "$val" | grep -qE '^[0-9]+$'; then
+  [ "$val" = "$cur_num" ] && ok=1                       # assigned by milestone number
+else
+  vtok=$(printf '%s' "$val" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+  { [ -n "$vtok" ] && [ "$vtok" = "$cur_ver" ]; } && ok=1   # title carries the current version
+  [ "$val" = "$cur_title" ] && ok=1                    # exact title match
+fi
+[ "$ok" = 1 ] && exit 0
+
+block "issue/PR milestone must be the current release milestone.
+  current : #$cur_num  $cur_title
+  target  : $val
+Assign to #$cur_num (its number, title, or $cur_ver). To defer to the backlog on purpose, prefix: MILESTONE_GUARD_OFF=1 <cmd>"

--- a/.claude/hooks/milestone-guard.sh
+++ b/.claude/hooks/milestone-guard.sh
@@ -66,18 +66,12 @@ val=$(printf '%s' "$val" | sed -E 's/^["'"'"']//; s/["'"'"']$//')
 # Empty target = clearing the milestone; not a scatter.
 [ -n "$val" ] || exit 0
 
-# --- Resolve the current release milestone ------------------------------------
-REPO="${REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)}"
-[ -n "$REPO" ] || block "cannot determine repo to verify milestone — set REPO=owner/name, or bypass with MILESTONE_GUARD_OFF=1"
-
-cur=$(gh api "repos/$REPO/milestones?state=open&per_page=100" --jq '
-  [ .[]
-    | select(.title | test("^v[0-9]+\\.[0-9]+\\.0"))
-    | . + { _k: ((.title | capture("^v(?<a>[0-9]+)\\.(?<b>[0-9]+)")) | (.a|tonumber) * 100000 + (.b|tonumber)) }
-  ]
-  | sort_by(._k) | .[0] // empty
-  | if . == "" then "" else "\(.number)\t\(.title)" end' 2>/dev/null || true)
-
+# --- Resolve the current release milestone (shared resolver) ------------------
+root="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+resolver="$root/scripts/current-milestone.sh"
+[ -f "$resolver" ] || block "current-milestone resolver missing ($resolver) — cannot verify milestone; bypass with MILESTONE_GUARD_OFF=1"
+cur=$(bash "$resolver" 2>/dev/null) \
+  || block "cannot determine repo to verify milestone — set REPO=owner/name, or bypass with MILESTONE_GUARD_OFF=1"
 [ -n "$cur" ] || block "no open version milestone (vX.Y.0) to assign into — create the release milestone first, or bypass with MILESTONE_GUARD_OFF=1.
   target: $val"
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/linkage-guard.sh"
+          },
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/milestone-guard.sh"
           }
         ]
       }

--- a/scripts/check-linkage.sh
+++ b/scripts/check-linkage.sh
@@ -5,6 +5,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 usage() {
   cat <<'EOF'
 check-linkage.sh — verify the issue <-> PR <-> milestone contract (see AGENTS.md "Milestones (ALWAYS)").
@@ -90,14 +92,9 @@ if [ -n "$FOR_TAG" ]; then
   TAG_MODE=1
 fi
 
-# Default to the current release milestone: the lowest-semver OPEN "vX.Y.0 …" one.
-# (Thematic/backlog milestones are not "current" — they carry no vX.Y.0 title.)
+# Default to the current release milestone (shared resolver = single source of truth).
 if [ -z "$MS" ]; then
-  MS=$(gh api "repos/$REPO/milestones?state=open&per_page=100" --jq '
-    [ .[]
-      | select(.title | test("^v[0-9]+\\.[0-9]+\\.0"))
-      | . + { _k: ((.title | capture("^v(?<a>[0-9]+)\\.(?<b>[0-9]+)")) | (.a|tonumber) * 100000 + (.b|tonumber)) }
-    ] | sort_by(._k) | .[0].number // empty')
+  MS=$(REPO="$REPO" bash "$SCRIPT_DIR/current-milestone.sh" 2>/dev/null | cut -f1 || true)
   # Fallback (no version milestone yet): lowest-numbered open, the legacy behaviour.
   [ -n "$MS" ] || MS=$(gh api "repos/$REPO/milestones?state=open&per_page=100" --jq 'sort_by(.number) | .[0].number // empty')
   [ -n "$MS" ] || { echo "error: no open milestone found in $REPO" >&2; exit 2; }

--- a/scripts/check-linkage.sh
+++ b/scripts/check-linkage.sh
@@ -90,9 +90,16 @@ if [ -n "$FOR_TAG" ]; then
   TAG_MODE=1
 fi
 
-# Default to the lowest-numbered open milestone (the "active" one).
+# Default to the current release milestone: the lowest-semver OPEN "vX.Y.0 …" one.
+# (Thematic/backlog milestones are not "current" — they carry no vX.Y.0 title.)
 if [ -z "$MS" ]; then
-  MS=$(gh api "repos/$REPO/milestones?state=open&per_page=100" --jq 'sort_by(.number) | .[0].number // empty')
+  MS=$(gh api "repos/$REPO/milestones?state=open&per_page=100" --jq '
+    [ .[]
+      | select(.title | test("^v[0-9]+\\.[0-9]+\\.0"))
+      | . + { _k: ((.title | capture("^v(?<a>[0-9]+)\\.(?<b>[0-9]+)")) | (.a|tonumber) * 100000 + (.b|tonumber)) }
+    ] | sort_by(._k) | .[0].number // empty')
+  # Fallback (no version milestone yet): lowest-numbered open, the legacy behaviour.
+  [ -n "$MS" ] || MS=$(gh api "repos/$REPO/milestones?state=open&per_page=100" --jq 'sort_by(.number) | .[0].number // empty')
   [ -n "$MS" ] || { echo "error: no open milestone found in $REPO" >&2; exit 2; }
 fi
 

--- a/scripts/current-milestone.sh
+++ b/scripts/current-milestone.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# current-milestone.sh — print the CURRENT release milestone as "<number>\t<title>".
+# Prints nothing (exit 0) when no version milestone is open.
+#
+# "Current" = the single open milestone whose title starts with `vX.Y.0` (lowest
+# semver if several are open). Single source of truth for "which milestone is
+# current" — shared by scripts/check-linkage.sh and .claude/hooks/milestone-guard.sh.
+#
+# Env: REPO=owner/name overrides the repo (default: gh repo view of the checkout).
+# Exit: 0 ok (may print empty) | 2 cannot determine repo.
+set -uo pipefail
+
+REPO="${REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)}"
+[ -n "$REPO" ] || { echo "current-milestone: cannot determine repo — set REPO=owner/name" >&2; exit 2; }
+
+gh api "repos/$REPO/milestones?state=open&per_page=100" --jq '
+  [ .[]
+    | select(.title | test("^v[0-9]+\\.[0-9]+\\.0"))
+    | . + { _k: ((.title | capture("^v(?<a>[0-9]+)\\.(?<b>[0-9]+)")) | (.a|tonumber) * 100000 + (.b|tonumber)) }
+  ]
+  | sort_by(._k) | (.[0] // null)
+  | if . == null then empty else "\(.number)\t\(.title)" end'


### PR DESCRIPTION
## What

Adds `.claude/hooks/milestone-guard.sh` — a `PreToolUse(Bash)` hook that hard-blocks assigning an issue or PR to any milestone **other than the current release milestone** (the single open `vX.Y.0 …`, lowest semver if several are open).

- Fires **only** on `gh` milestone-assignment *writes* — `gh issue|pr edit|create --milestone`, `gh api … -F milestone=`. Reads, lists, non-`gh`, and non-milestone commands pass with no network call (~0 tokens).
- Wrong target → blocked (exit 2) with the current milestone named.
- Bypass a deliberate backlog/deferral move: `MILESTONE_GUARD_OFF=1 <cmd>`.

Also aligns the **"active milestone"** definition so the tooling agrees end-to-end: the bare `scripts/check-linkage.sh` audit now resolves the active milestone to the current `vX.Y.0` release milestone instead of the *lowest-numbered open* one — which was resolving to a backlog milestone, not the release being cut. The legacy lowest-number path is kept as a fallback for when no version milestone exists.

Wired next to `linkage-guard` in `.claude/settings.json`.

## Why

Work kept landing in the wrong / freshly-created milestones because "active milestone" was defined as *lowest-numbered open*, which resolved to a phase-backlog milestone rather than the release in progress. This pins a single, deterministic source of truth for "current" and enforces it on assignment.

## Reviewer notes

- Verified against a 12-case matrix: reads / non-`gh` pass; assigning to the current milestone by number, title, or `vX.Y.0` token passes; other numbers/titles block; `MILESTONE_GUARD_OFF=1` and `--remove-milestone` pass.
- Guards the agent's `gh` calls only — not GitHub-UI edits or other clients (same limitation as `linkage-guard`).
- **`AGENTS.md` doc updates are intentionally not in this PR** — repo rule: don't commit `AGENTS.md` without an explicit ask. Those pending edits redefine "active milestone" and document the new hook; the committed `check-linkage.sh`/hook behavior matches them. Say the word to fold them in.
- **No milestone on this PR by design** — it's meta-tooling, not `v1.2.0` release work. Assigning it to the release milestone would break the `--for-tag` gate (a PR that closes no release issue fails tag-readiness). If you'd rather track it, I can file a tooling issue + milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
