### PR TITLE
test(db): concurrency & resource-safety regression coverage for v1.2.0

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/001-concurrency-hardening"
+}

--- a/specs/001-concurrency-hardening/checklists/requirements.md
+++ b/specs/001-concurrency-hardening/checklists/requirements.md
@@ -1,0 +1,43 @@
+# Specification Quality Checklist: Statement Concurrency & Resource-Safety Hardening
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Source of scope: GitHub milestone 12 ("v1.2.0 — Connection-pool deadlock & concurrency
+  hardening"), open issues #83, #100, #120, #121. Closed items (#57/#59, #138, #139) and
+  follow-ups (#84, #88) are explicitly out of scope.
+- Domain terms retained deliberately: "parameterized statement", "stored procedure",
+  "query timeout", "connection pool" are the product's domain language (a JDBC load-testing
+  plugin), not implementation leakage. Issue numbers are traceability references required
+  by the repository's milestone/linkage rules.
+- No [NEEDS CLARIFICATION] markers: each issue specifies failure scenario, required fix,
+  and acceptance test; milestone description bounds scope.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`

--- a/specs/001-concurrency-hardening/contracts/jdbc-client-behavior.md
+++ b/specs/001-concurrency-hardening/contracts/jdbc-client-behavior.md
@@ -1,0 +1,76 @@
+# Behavioral Contract: JDBC Client Execution Guarantees
+
+**Date**: 2026-07-13 | **Plan**: [plan.md](plan.md)
+
+This feature changes no public signatures. The contract below states the runtime
+guarantees the plugin's DB layer makes to Gatling scenarios — the guarantees the
+new tests pin down. Consumers: Scala DSL users, `javaapi` (Java/Kotlin) users.
+
+## Unchanged public surface (FR-007)
+
+- `JdbcProtocolBuilder` / `JdbcProtocolBuilderConnectionSettingsStep` — incl.
+  `queryTimeout(FiniteDuration)` / `queryTimeout(java.time.Duration)`
+- `JDBCClient.{executeRaw, executeSelect, executeUpdate, call, batch, close}` —
+  signatures, `Try`-based consumer callbacks, `Future[U]` returns
+- `ParamVal` ADT, `SQL` / `SqlWithParam`, check DSL
+
+## Guarantee 1 — Serialized parameter binding (#120, FR-001)
+
+For any single `PreparedStatement`:
+
+- G1.1 At most one parameter-setter call (`setInt`/`setString`/…/`setObject`) is in
+  progress at any instant.
+- G1.2 Binding happens-before statement execution on the same thread.
+- G1.3 Values land at the JDBC indexes the interpolator derived from the SQL's
+  named placeholders; duplicate placeholder names bind every mapped index. Each index
+  is bound exactly once with its declared value. Relative order between distinct
+  indexes is unspecified (no driver requires one; adjusted after adversarial review).
+- G1.4 A binding failure (e.g., missing binding for a placeholder) fails the whole
+  operation with the original exception; the statement is never executed.
+
+## Guarantee 2 — Serialized IN/OUT registration (#121, FR-002)
+
+For any single `CallableStatement`:
+
+- G2.1 At most one setter or `registerOutParameter` call is in progress at any
+  instant; no IN/OUT overlap. Each IN index bound exactly once, each OUT index
+  registered exactly once; relative order between distinct indexes is unspecified.
+- G2.2 OUT-parameter registration and IN binding complete before execution.
+- G2.3 `call` returns the OUT values by name; missing OUT placeholders raise
+  `IllegalArgumentException` naming the missing parameters (existing behavior).
+
+## Guarantee 3 — Batch honors queryTimeout (#83, FR-003/FR-004)
+
+- G3.1 If `queryTimeout` is configured on the protocol, every statement a `batch`
+  prepares has that timeout applied before execution.
+- G3.2 A batch exceeding the timeout fails the operation (`Failure` → KO), within
+  timeout + a small driver margin; the transaction is rolled back and resources
+  released.
+- G3.3 If no timeout is configured, batch semantics are byte-for-byte today's:
+  no implicit timeout.
+- G3.4 Sub-second configured timeouts round up to 1 second (existing normalization).
+
+## Guarantee 4 — Release exactly once, error preserved (#100, FR-005/FR-006)
+
+- G4.1 Every acquired resource (connection, statement, result set, autocommit
+  guard) is released exactly once on success, on asynchronous failure, and on
+  synchronous throw before any deferred work exists.
+- G4.2 The caller's `Try` carries the ORIGINAL failure whenever release failures are
+  ordinary (non-fatal) exceptions; those release failures are attached as suppressed.
+  Per `scala.util.Using` severity ranking, fatal throwables raised during release
+  (`VirtualMachineError`, `ControlThrowable`, `InterruptedException`, `LinkageError`)
+  may take precedence over the original failure — the contract does not promise
+  otherwise (adjusted after adversarial review).
+- G4.3 After any failed operation, the connection returns to the pool: active
+  connection count reaches 0 once the operation completes.
+- G4.4 Repeated failing operations do not accumulate leaked resources (soak
+  stability).
+
+## Verification matrix
+
+| Guarantee | Test artifact (planned) | Real-DB path |
+|-----------|------------------------|--------------|
+| G1.* | `StatementParamsConcurrencySpec` (proxy) + H2/PG value round-trip | H2 + PostgreSQL |
+| G2.* | `StatementParamsConcurrencySpec` (proxy) + stored-proc under load | PostgreSQL (function), H2 alias |
+| G3.* | `BatchQueryTimeoutSpec` | PostgreSQL (`pg_sleep`), H2 fast-path |
+| G4.* | `ResourceReleaseOnSyncThrowSpec` — close-counting proxy resources (exactly-once per connection/statement), op-failure × release-failure case asserting primary vs suppressed, Hikari pool metrics, soak loop | H2 |

--- a/specs/001-concurrency-hardening/data-model.md
+++ b/specs/001-concurrency-hardening/data-model.md
@@ -1,0 +1,66 @@
+# Data Model: Statement Concurrency & Resource-Safety Hardening
+
+**Date**: 2026-07-13 | **Plan**: [plan.md](plan.md)
+
+No new data structures are introduced. The feature verifies invariants over the
+existing model. Entities from the spec map to existing types as follows.
+
+## Entity mapping
+
+### Statement operation (spec: "one database action a virtual user performs")
+
+| Aspect | Existing implementation |
+|--------|------------------------|
+| Kinds | raw SQL (`JDBCClient.executeRaw`), query (`executeSelect`), update/insert (`executeUpdate`), stored-procedure call (`call`), batch (`batch`) — `src/main/scala/org/galaxio/gatling/jdbc/db/JDBCClient.scala` |
+| Ownership | Each operation = exactly one `Future` on the blocking pool; all JDBC work for the operation happens synchronously inside it (post-#59 invariant) |
+| Timeout attribute | `queryTimeout: Option[FiniteDuration]` on `JDBCClient`, normalized to `queryTimeoutSeconds: Option[Int]` (sub-second rounds up to 1s) |
+
+### Parameter binding (spec: "one value ↔ one position; unit whose overlap is eliminated")
+
+| Aspect | Existing implementation |
+|--------|------------------------|
+| Value type | `ParamVal` ADT — `IntParam`, `LongParam`, `DoubleParam`, `StrParam`, `DateParam`, `BooleanParam`, `UUIDParam`, `NullParam` (`db/package.scala`) |
+| Position resolution | `Interpolator.InterpolatorCtx.m: Map[String, List[Int]]` — named placeholder → 1-based JDBC indexes (`JDBCClient.scala:14-38`) |
+| Binding execution | `statements.PreparedStatementOps.setParams` / `CallableStatementOps.setParams` — synchronous `foreach`, single thread (`statements.scala`) |
+| **Invariant under test** | Max concurrent setter/`registerOutParameter` entry per statement == 1; each position bound/registered exactly once with its declared value; cross-position order unspecified (FR-001/FR-002) |
+
+### Managed resource (spec: "pooled artifact released exactly once on all paths")
+
+| Aspect | Existing implementation |
+|--------|------------------------|
+| Kinds | `Connection` (HikariCP pool), `Statement`/`PreparedStatement`/`CallableStatement`, `ResultSet`, `DisableAutoCommit` guard (batch) |
+| Lifecycle | `scala.util.Using.Manager` registers each; releases LIFO exactly once on success, async failure, and synchronous throw (`JDBCClient.scala:53-93`) |
+| **Invariant under test** | After sync-throw failure: original exception surfaces in `Failure` (non-fatal release failures suppressed, per `Using` severity ranking); each resource's `close()` invoked exactly once (counting proxies); Hikari active-connection count returns to 0 (FR-005/FR-006) |
+
+### Query timeout (spec: "protocol-level max duration, extended to batches")
+
+| Aspect | Existing implementation |
+|--------|------------------------|
+| DSL source | `JdbcProtocolBuilder…queryTimeout(FiniteDuration)` (Scala), `JdbcProtocolBuilderConnectionSettingsStep.queryTimeout(Duration)` (Java facade) |
+| Wiring | Builder → `JdbcProtocol` → `JDBCClient` (`JdbcProtocol.scala:36`) |
+| Application | `stmt.setQueryTimeout` in `withStatement`, `withPreparedStatement`, `withCallableStatement`, and per batch statement (`JDBCClient.scala:64,75,89,169`) |
+| **Invariant under test** | Slow batch aborts as `Failure` within timeout + margin; unset timeout ⇒ unchanged behavior (FR-003/FR-004) |
+
+## State transitions
+
+Operation lifecycle (unchanged, verified):
+
+```text
+acquire connection → [batch only: disable autoCommit] → prepare statement
+  → set timeout → bind params (SEQUENTIAL) → execute → read results
+  → [batch only: commit | rollback] → release all resources (ALWAYS, exactly once)
+  → consumer(Try[result]) → restore autoCommit → return connection to pool
+```
+
+Failure at ANY step short-circuits to the release path with the original error
+preserved in the `Try`.
+
+## Validation rules (from FRs)
+
+- FR-001/FR-002: binding/registration serialized per statement; every position exactly
+  once with its declared value (no cross-position order guarantee).
+- FR-003/FR-004: timeout applied to batch statements iff configured.
+- FR-005/FR-006: release exactly once on every path; original error preserved for
+  non-fatal cleanup failures (cleanup error suppressed).
+- FR-007: no signature/default/observable-behavior change for working scenarios.
+- FR-008: every invariant above pinned by a test on a real DB path.

--- a/specs/001-concurrency-hardening/plan.md
+++ b/specs/001-concurrency-hardening/plan.md
@@ -1,0 +1,107 @@
+# Implementation Plan: Statement Concurrency & Resource-Safety Hardening
+
+**Branch**: `001-concurrency-hardening` | **Date**: 2026-07-13 | **Spec**: [spec.md](spec.md)
+
+**Input**: Feature specification from `/specs/001-concurrency-hardening/spec.md`
+
+**Note**: This template is filled in by the `/speckit-plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Close the four remaining open defects of milestone v1.2.0 (#83, #100, #120, #121).
+Phase 0 research established that PR #59 already removed every defect mechanism on
+current `main` (synchronous `setParams`, `Using.Manager` resource handling, batch
+`setQueryTimeout` applied). The work is therefore verification-driven: add the
+acceptance/regression test each issue prescribes, on real databases (H2 /
+PostgreSQL-Testcontainers) plus JDK-proxy concurrency instrumentation, prove each
+guarantee holds, fix any residual gap a test exposes (only realistic candidate:
+batch-timeout abort semantics, #83), and close the issues with 1-issue-=-1-commit
+traceability. Full analysis: [research.md](research.md).
+
+## Technical Context
+
+**Language/Version**: Scala 2.13.18 (core), Java 17+ (Temurin in CI), Kotlin for facade tests
+
+**Primary Dependencies**: Gatling 3.13.5, HikariCP, sbt; test: ScalaTest, H2, PostgreSQL via Testcontainers
+
+**Storage**: H2 in-memory + PostgreSQL (Testcontainers) — test targets only; plugin itself is DB-agnostic over JDBC
+
+**Testing**: ScalaTest (`AnyFlatSpec`+`Matchers` house style); Gatling example simulation `DebugTest` on H2; `sbt scalafmtCheckAll scalafmtSbtCheck compile test` is the gate
+
+**Target Platform**: JVM 17+ library (Gatling plugin), consumed by Scala/Java/Kotlin load tests
+
+**Project Type**: Single sbt library project with `src/main/{scala,java}` and `src/test/{scala,java,kotlin}`
+
+**Performance Goals**: No throughput regression in statement preparation (binding already serialized post-#59; tests must not add production overhead — instrumentation lives in test code only)
+
+**Constraints**: Backward compatibility of published Scala DSL / javaapi facade (Constitution I, NON-NEGOTIABLE); no new dependencies; no mocks where a real DB path exists (Constitution II); blocking JDBC work stays on the dedicated blocking pool
+
+**Scale/Scope**: 4 issues, ~4 new/extended test specs, 0–1 small production fix (contingent on #83 verification), 3 existing source files in `db/` as the verified surface
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Gate | Status |
+|-----------|------|--------|
+| I. Backward Compatibility | No published signature/default/behavior change for working scenarios | PASS — test-only work planned; contingent #83 fix is internal to `batch` execution, observable only as "configured timeout now honored" (the spec'd intent, FR-003/FR-007) |
+| II. Test-First With Real Databases | Behavior guarantees proven on H2/PostgreSQL, not mocks; every commit green on default gate | PASS — each issue's acceptance test runs a real DB path; JDK-proxy instrumentation is issue-prescribed concurrency measurement, always paired with real-DB value verification (see Complexity Tracking) |
+| III. Resource & Concurrency Safety | Release-on-all-paths, timeout, thread behavior explicitly considered | PASS — this feature *is* the verification of III; PR text will state pool/timeout/thread analysis per issue |
+| IV. Spec-Driven, Semantic Delivery | Spec artifacts land first as `docs(speckit)`; 1 issue = 1 commit; milestone linkage | PASS — spec committed before implementation; commit map in research.md; all 4 issues in milestone v1.2.0 |
+| V. Idiomatic Simplicity | Smallest clear change; no premature abstraction | PASS — no production seams added for testability; pool metrics + dynamic proxies keep instrumentation in tests |
+
+**Post-Phase-1 re-check**: PASS — design adds no contracts changes, no new entities, no dependencies.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-concurrency-hardening/
+├── plan.md              # This file (/speckit-plan command output)
+├── research.md          # Phase 0 output (/speckit-plan command)
+├── data-model.md        # Phase 1 output (/speckit-plan command)
+├── quickstart.md        # Phase 1 output (/speckit-plan command)
+├── contracts/
+│   └── jdbc-client-behavior.md   # Behavioral contract being verified
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (from /speckit-specify)
+└── tasks.md             # Phase 2 output (/speckit-tasks command - NOT created by /speckit-plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/main/scala/org/galaxio/gatling/jdbc/
+├── db/
+│   ├── JDBCClient.scala          # Verified surface: withPreparedStatement/withCallableStatement/batch/timeout (possible #83 contingency fix)
+│   ├── statements.scala          # Verified surface: synchronous setParams (PS + CS)
+│   └── package.scala             # ParamVal ADT, SqlWithParam (read-only for this feature)
+└── protocol/
+    ├── JdbcProtocol.scala        # queryTimeout wiring (read-only, already covered)
+    └── JdbcProtocolBuilder.scala # queryTimeout DSL (read-only, already covered)
+
+src/test/scala/org/galaxio/gatling/jdbc/
+├── db/
+│   ├── StatementParamsConcurrencySpec.scala   # NEW — #120/#121 proxy instrumentation (max concurrent entry == 1)
+│   ├── BatchQueryTimeoutSpec.scala            # NEW — #83 acceptance (slow batch → KO within timeout; fast batch unchanged; no-timeout unchanged)
+│   ├── ResourceReleaseOnSyncThrowSpec.scala   # NEW — #100 acceptance (sync throw → original exception; close-counting proxies exactly-once; op-failure × close-failure suppression case; pool metrics; soak loop)
+│   ├── PostgreSQLIntegrationSpec.scala        # EXTEND — concurrent value-correctness + stored-proc IN/OUT under load
+│   ├── BatchPreparedStatementSpec.scala       # existing (H2 batch values) — reference conventions
+│   └── JDBCClientThreadingSpec.scala          # existing (pool growth) — reference conventions
+└── actions/
+    └── DBCallActionOutParamSpec.scala         # existing OUT-param extraction — reference conventions
+```
+
+**Structure Decision**: Single existing sbt project; all new artifacts are ScalaTest
+specs under `src/test/scala/org/galaxio/gatling/jdbc/db/`, following the naming and
+style of the neighbouring specs. Production edits, if any, confined to
+`JDBCClient.batch`.
+
+## Complexity Tracking
+
+> Fill ONLY if Constitution Check has violations that must be justified
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| JDK dynamic proxy over `PreparedStatement`/`CallableStatement` in tests (brushes against "no mocks where real path exists", Constitution II) | Issues #120/#121 explicitly prescribe a "barrier proxy asserts maxConcurrent setter calls is 1" — concurrency-of-binding is unobservable through a real driver | Real-DB-only test cannot detect overlapped setter calls (drivers may tolerate or mask them); proxy measures the invariant itself. Every proxy test is paired with a real H2/PostgreSQL value-verification test, so the real path stays authoritative |

--- a/specs/001-concurrency-hardening/quickstart.md
+++ b/specs/001-concurrency-hardening/quickstart.md
@@ -1,0 +1,45 @@
+# Quickstart: Validating Statement Concurrency & Resource-Safety Hardening
+
+**Plan**: [plan.md](plan.md) | **Contract**: [contracts/jdbc-client-behavior.md](contracts/jdbc-client-behavior.md)
+
+## Prerequisites
+
+- JDK 17+, sbt (repo toolchain)
+- Docker running — PostgreSQL Testcontainers specs (`BatchQueryTimeoutSpec`,
+  `PostgreSQLIntegrationSpec`) skip or fail without it
+- One-time per clone: `bash scripts/install-hooks.sh`
+
+## Full gate (what CI runs)
+
+```bash
+sbt scalafmtCheckAll scalafmtSbtCheck compile test
+```
+
+Expected: all green, including the four new/extended specs.
+
+## Per-issue validation
+
+| Issue | Command | Expected outcome |
+|-------|---------|------------------|
+| #120 PS binding serialized | `sbt "testOnly org.galaxio.gatling.jdbc.db.StatementParamsConcurrencySpec"` | max concurrent setter entry == 1; H2 round-trip values 100% correct |
+| #121 CS IN/OUT serialized | same spec (callable cases) + `sbt "testOnly org.galaxio.gatling.jdbc.db.PostgreSQLIntegrationSpec"` | no overlapped registration; stored-proc OUT values correct under load |
+| #83 batch timeout | `sbt "testOnly org.galaxio.gatling.jdbc.db.BatchQueryTimeoutSpec"` | slow batch → `Failure` (KO) within timeout+margin; fast batch OK; no-timeout unchanged |
+| #100 release on sync throw | `sbt "testOnly org.galaxio.gatling.jdbc.db.ResourceReleaseOnSyncThrowSpec"` | original exception surfaced; Hikari active connections back to 0; soak loop leak-free |
+
+## End-to-end example simulation (regression guard)
+
+```bash
+sbt "Gatling / testOnly org.galaxio.performance.jdbc.test.DebugTest"
+```
+
+Expected: simulation passes on H2 exactly as before (Constitution II / SC-005).
+
+## Milestone close-out check
+
+```bash
+scripts/check-linkage.sh            # audit active milestone (v1.2.0)
+gh api repos/galax-io/gatling-jdbc-plugin/milestones/12 --jq '{open: .open_issues, closed: .closed_issues}'
+```
+
+Expected after implementation lands: #83, #100, #120, #121 closed via merged PR(s),
+milestone open-issue count 0 → tag-ready per release discipline.

--- a/specs/001-concurrency-hardening/research.md
+++ b/specs/001-concurrency-hardening/research.md
@@ -1,0 +1,167 @@
+# Phase 0 Research: Statement Concurrency & Resource-Safety Hardening
+
+**Date**: 2026-07-13
+**Spec**: [spec.md](spec.md)
+**Audit baseline (issues)**: `a8d0401bd92ea694f5f550dd279e61d5581408c3`
+**Current baseline (this plan)**: `main` @ `75925b6` (post-#59)
+
+## Central finding
+
+All four open issues (#83, #100, #120, #121) were filed against audit baseline
+`a8d0401`, **before** PR #59 ("Fix Deadlock on Backpressure From Connection Pool",
+commit `38b99bd`) landed. #59 collapsed each DB operation into a single `Future`
+with synchronous `Using`-based resource handling — which structurally removed the
+root cause (per-step `Future` boundaries) shared by all four defects.
+
+**On current `main`, every defect mechanism named in the issues is already gone.**
+What is missing is the acceptance/regression test each issue demands. This feature
+is therefore primarily a **verification and regression-coverage** effort: prove each
+fix on a real database, lock it in with tests, and close the issues. Production code
+changes only if a test exposes a residual defect.
+
+## Per-issue analysis
+
+### #120 — PreparedStatement setters launched concurrently (P0-A05a)
+
+- **Baseline defect**: `statements.scala:62-91` created one eager `Future` per
+  parameter setter and combined them with `reduce`; on a multi-thread executor,
+  setters for one statement could interleave.
+- **Current state**: `statements.scala:9-26` (`PreparedStatementOps.setParams`) is a
+  plain synchronous `foreach` — no `Future`, no `ExecutionContext` in signature. All
+  binding happens on the single blocking-pool thread that runs the operation's one
+  `Future` (`JDBCClient.withPreparedStatement`, `JDBCClient.scala:68-78`).
+- **Decision**: no production change. Add regression tests:
+  1. Instrumented-proxy test (`java.lang.reflect.Proxy` over `PreparedStatement`)
+     recording concurrent-entry count of setter calls; assert max == 1. Guards
+     against reintroduction of per-setter futures.
+  2. Real-DB (H2) multi-parameter value-correctness test under concurrent virtual
+     users: distinct known values written via `executeUpdate`, read back, assert
+     100% correct.
+- **Rationale**: issue's own acceptance test prescribes "barrier proxy asserts
+  maxConcurrent setter calls is 1 and H2 verifies values".
+- **Alternatives considered**: byte-buddy/mockito instrumentation of driver classes —
+  rejected (heavier dependency, Constitution: no new deps without approval; JDK
+  dynamic proxy over the `java.sql.PreparedStatement` interface suffices).
+
+### #121 — CallableStatement IN/OUT registration launched concurrently (P0-A05b)
+
+- **Baseline defect**: `statements.scala:103-148` eagerly created futures for IN
+  setters and `registerOutParameter`; registration could overlap on one statement.
+- **Current state**: `statements.scala:28-55` (`CallableStatementOps.setParams`) is a
+  synchronous `foreach` over the interpolated index map; IN binding and OUT
+  registration happen sequentially on one thread inside
+  `JDBCClient.withCallableStatement` (`JDBCClient.scala:80-93`).
+- **Decision**: no production change. Add regression tests:
+  1. Proxy test over `CallableStatement` asserting max concurrent
+     setter/registerOutParameter entry == 1 and that no call overlaps another.
+  2. Real stored-procedure test (H2 `CREATE ALIAS` or PostgreSQL function via
+     Testcontainers) with both IN and OUT params under concurrent load; assert every
+     call returns correct OUT values. `DBCallActionOutParamSpec` already covers
+     single-call OUT extraction; the new test adds the concurrency dimension.
+- **Rationale / alternatives**: same as #120.
+
+### #83 — Batch statements ignore configured queryTimeout (P0-A07)
+
+- **Baseline defect**: `JDBCClient.scala:169-170` (baseline) prepared batch
+  statements without applying `queryTimeoutSeconds`.
+- **Current state**: `batch` applies the timeout to every prepared batch statement —
+  `JDBCClient.scala:169` (`queryTimeoutSeconds.foreach(stmt.setQueryTimeout)` inside
+  `Using(conn.prepareStatement(...))`). Wiring from protocol verified:
+  `JdbcProtocolBuilder.queryTimeout` → `JdbcProtocol` → `JDBCClient`
+  (`JdbcProtocol.scala:36`, covered by `JdbcProtocolBuilderSpec`).
+- **Open verification question**: does a driver-observed timeout actually abort a
+  slow batch and surface as `Failure` (KO)? Code sets it; no test proves it fires.
+  PostgreSQL honors `setQueryTimeout` via statement cancel; H2 supports it via
+  `pg_sleep`-equivalent (`SLEEP()` in a batch row must be arranged carefully — a
+  PostgreSQL Testcontainers test with `pg_sleep` in a batched INSERT-SELECT is the
+  reliable real path; `PostgreSQLIntegrationSpec` already has slow-query/timeout
+  precedent at lines 110-134).
+- **Decision**: no production change expected. Add acceptance test: batch whose
+  execution exceeds a short configured `queryTimeout` fails within timeout + margin;
+  companion tests assert fast-batch success and no-timeout-configured behavior
+  unchanged. If the test shows the timeout NOT firing (driver semantics), fix batch
+  execution accordingly — that would be the one code change, scoped to `batch`.
+- **Alternatives considered**: unit-test that `setQueryTimeout` was called via proxy
+  only — rejected as primary test (Constitution II demands real DB path; proxy
+  doesn't prove abort semantics). May complement.
+
+### #100 — ResourceFut skips release when use throws synchronously (P1-A24)
+
+- **Baseline defect**: `ResourceFut.scala:14-27` called `f(res)` before installing
+  `transformWith` cleanup; a synchronous throw skipped release.
+- **Current state**: `ResourceFut.scala` **deleted** by #59. All resource handling is
+  `scala.util.Using.Manager` (`JDBCClient.scala:53-93`), which releases every
+  registered resource exactly once on all paths including synchronous throws.
+  Error-preservation follows `Using`'s severity ranking: an ordinary (non-fatal)
+  release failure is suppressed under the original exception, but a fatal throwable
+  raised during release (`VirtualMachineError`, `ControlThrowable`,
+  `InterruptedException`, `LinkageError`) takes precedence. The contract (G4.2) is
+  scoped to exactly this — adversarial review caught the earlier over-claim
+  ("always preserves the original").
+- **Existing partial coverage**: `PostgreSQLIntegrationSpec:154-176` asserts
+  connections return to pool after success and after failed query;
+  `JDBCClientFailureSpec` asserts original SQL exceptions surface in the `Try`.
+- **Decision**: no production change. Add focused regression tests pinning the
+  sync-throw path (scope widened after adversarial review):
+  1. Sync failure → `Failure` carries the original exception; pool active-connection
+     count returns to 0 (HikariCP `HikariPoolMXBean`).
+  2. **Close-counting proxies**: test-only `HikariDataSource` subclass returning
+     dynamic-proxy `Connection`s (and proxy statements) that count `close()` per
+     resource → assert exactly-once release for every acquired resource, not just
+     pool-level return.
+  3. **Combined-failure case**: operation fails AND a proxy resource's `close()`
+     throws a non-fatal exception → assert the original exception is primary and the
+     close failure is attached as suppressed (pins G4.2 as narrowed).
+  4. Repeat-loop soak variant guards leak-per-iteration.
+- **Alternatives considered**: production-code instrumentation seam to count
+  `close()` — rejected (Constitution V, premature abstraction); the test-only
+  `HikariDataSource` subclass + JDK proxies deliver per-resource counting with zero
+  production change. Pool-metrics-only verification — rejected as sole check after
+  adversarial review: zero active connections cannot prove per-resource
+  exactly-once release or error-suppression behavior.
+
+## Cross-cutting decisions
+
+- **Test placement**: new specs under `src/test/scala/org/galaxio/gatling/jdbc/db/`
+  (mechanism-level) mirroring existing `BatchPreparedStatementSpec` /
+  `PostgreSQLIntegrationSpec` / `JDBCClientThreadingSpec` conventions; ScalaTest
+  `AnyFlatSpec` + `Matchers` as in existing specs.
+- **Real DB choice per test**: H2 in-memory for value-correctness and proxy-free
+  paths (fast, CI-cheap); PostgreSQL Testcontainers where driver semantics matter
+  (batch timeout abort, stored-procedure OUT under load).
+- **No new dependencies**: JDK dynamic proxies + existing ScalaTest/Testcontainers/H2
+  stack covers everything. (Constitution: new deps need approval — none needed.)
+- **No public API change**: all four issues are internal-behavior; signatures,
+  defaults, DSL untouched (Constitution I).
+- **Commit mapping** (Constitution IV): 1 issue = 1 commit, `test(db): … (#NNN)` when
+  test-only, `fix(db): … (#NNN)` if #83 verification exposes a real driver gap.
+  Spec/plan artifacts land first as `docs(speckit): …`.
+
+## Unknowns resolved
+
+Spec contained no [NEEDS CLARIFICATION]. Technical unknowns identified during
+planning and their resolutions:
+
+| Unknown | Resolution |
+|---------|------------|
+| Do the audited defects still exist on `main`? | No — #59 removed all four mechanisms (verified by reading current `db/` sources). |
+| Does batch timeout actually abort on a real driver? | To be proven by the #83 acceptance test (PostgreSQL `pg_sleep`); contingency fix scoped if not. |
+| How to measure setter concurrency without mocking the DB? | JDK dynamic proxy around the statement interface, per issue-prescribed acceptance test; value correctness still proven on real H2/PG. |
+| How to prove release-exactly-once without a test seam? | Test-only `HikariDataSource` subclass + close-counting JDK proxies (per-resource exactly-once), plus HikariCP `HikariPoolMXBean` pool-level check. |
+
+## Adversarial-review adjustments (2026-07-13)
+
+Codex adversarial review (verdict: needs-attention) forced two spec-level corrections
+before implementation:
+
+1. **[high] G4.1/G4.2 over-claimed vs `scala.util.Using` semantics.** `Using` picks the
+   primary throwable by severity; a fatal release failure can replace the original
+   operation failure. Contract narrowed to "non-fatal release failure never masks
+   (suppressed)"; #100 test plan extended with close-counting proxies and an
+   op-failure × close-failure case. (Related but out of scope: #84 rollback masking.)
+2. **[medium] "Deterministic order = declaration order" was unimplementable and
+   untested.** Placeholder→index storage is `Map[String, List[Int]]` (unordered; index
+   lists built by prepend). FR-001/FR-002 narrowed to "no overlap + every index bound
+   exactly once with its declared value"; no cross-index order guarantee. Drivers do
+   not require one; requiring it would force a production rewrite with no user-visible
+   benefit.

--- a/specs/001-concurrency-hardening/spec.md
+++ b/specs/001-concurrency-hardening/spec.md
@@ -1,0 +1,248 @@
+# Feature Specification: Statement Concurrency & Resource-Safety Hardening
+
+**Feature Branch**: `001-concurrency-hardening`
+
+**Created**: 2026-07-13
+
+**Status**: Draft
+
+**Input**: User description: "https://github.com/galax-io/gatling-jdbc-plugin/milestone/12 — v1.2.0 Connection-pool deadlock & concurrency hardening (remaining open issues: #83, #100, #120, #121)"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Correct parameter binding for parameterized queries under load (Priority: P1)
+
+A performance engineer runs a load test where many virtual users execute parameterized
+queries and inserts at the same time. Every statement must receive exactly the parameter
+values the test author specified, in the positions they specified — regardless of how many
+virtual users run concurrently or how the execution environment schedules work.
+
+Today, the values of a single statement's parameters can be applied concurrently with each
+other, so two parameters of one statement may be bound out of order or corrupt one another
+when work is spread across threads. (Issue #120)
+
+**Why this priority**: Silently corrupted parameter bindings invalidate load-test results
+and can write wrong data to the system under test. This is the highest-severity class of
+defect for a testing tool: the tool itself lies about what it tested.
+
+**Independent Test**: Can be fully tested by running a parameterized statement with
+multiple parameters through an instrumented binding layer that records overlapping
+binding calls, and by verifying stored values against a real database.
+
+**Acceptance Scenarios**:
+
+1. **Given** a parameterized statement with two or more parameters, **When** the statement
+   is prepared and executed on a multi-threaded execution environment, **Then** at most one
+   parameter binding is in progress at any instant (no overlap) and every parameter
+   position receives exactly its declared value, bound exactly once.
+2. **Given** a load scenario inserting known distinct values through parameterized inserts,
+   **When** the scenario completes against a real database, **Then** every row read back
+   contains exactly the values the test author supplied — no swapped or corrupted values.
+3. **Given** a parameterized statement whose binding fails (e.g., invalid value), **When**
+   the failure occurs, **Then** the operation is reported as failed (KO) with the original
+   error and no partially-bound statement is executed.
+
+---
+
+### User Story 2 - Reliable stored-procedure input/output registration under load (Priority: P2)
+
+A performance engineer load-tests stored procedures that take input parameters and return
+output parameters. Input binding and output registration for a single call must happen
+one at a time and in a predictable order, so the driver never sees overlapping or
+misordered registration on the same call.
+
+Today, input binding and output registration for one stored-procedure call can run
+concurrently, causing driver errors or values registered at wrong positions. (Issue #121)
+
+**Why this priority**: Same defect class as User Story 1 (corrupted test execution), but
+scoped to stored-procedure users — a narrower audience than plain parameterized queries.
+
+**Independent Test**: Can be fully tested by instrumenting a stored-procedure call to
+record overlapping binding/registration calls, and by invoking a real stored procedure
+that returns output values and verifying the results.
+
+**Acceptance Scenarios**:
+
+1. **Given** a stored-procedure call with both input and output parameters, **When** the
+   call is prepared on a multi-threaded execution environment, **Then** at most one
+   binding or registration action is in progress at any instant, every input position is
+   bound exactly once, and every output position is registered exactly once.
+2. **Given** a real stored procedure with input and output parameters, **When** it is
+   executed under load, **Then** every call returns the correct output values for its
+   inputs.
+
+---
+
+### User Story 3 - Batch operations honor the configured query timeout (Priority: P3)
+
+A performance engineer configures a query timeout on the protocol so that slow database
+operations fail fast instead of stalling the load test. Batch operations must respect this
+timeout exactly like single-statement operations already do.
+
+Today, batch operations ignore the configured timeout: a slow batch can wait indefinitely
+even when a timeout is configured. (Issue #83)
+
+**Why this priority**: A hung batch stalls virtual users and can mask the very
+degradation the load test exists to detect — but it corrupts liveness, not data, so it
+ranks below the binding-correctness stories.
+
+**Independent Test**: Can be fully tested by running a deliberately slow batch against a
+real database with a short configured timeout and asserting the operation fails within
+the timeout window.
+
+**Acceptance Scenarios**:
+
+1. **Given** a protocol configured with a query timeout of N seconds, **When** a batch
+   operation exceeds N seconds, **Then** the operation is aborted and reported as failed
+   (KO) rather than waiting indefinitely.
+2. **Given** a protocol configured with a query timeout, **When** a batch completes within
+   the timeout, **Then** it succeeds exactly as before (no behavior change for fast
+   batches).
+3. **Given** no query timeout is configured, **When** a batch runs, **Then** existing
+   behavior is unchanged (no implicit timeout is introduced).
+
+---
+
+### User Story 4 - Resources are always released when an operation fails immediately (Priority: P4)
+
+A performance engineer runs long soak tests. Every database resource the plugin acquires
+(connections, statements) must be returned on every path — including when an operation
+fails immediately upon starting, before any asynchronous work begins.
+
+Today, if the work given to a managed resource fails synchronously (before deferred work
+is set up), the resource's release step is skipped, leaking the resource. (Issue #100)
+
+**Why this priority**: The leak requires a specific failure mode (immediate synchronous
+failure) to trigger, so it is less frequent than the always-on defects above — but under
+soak load, repeated leaks exhaust the connection pool and halt the test.
+
+**Independent Test**: Can be fully tested by handing a managed resource a task that throws
+immediately and asserting the resource is released exactly once and the original error is
+preserved.
+
+**Acceptance Scenarios**:
+
+1. **Given** a managed resource whose consuming task fails immediately (synchronously),
+   **When** the failure occurs, **Then** the resource is released exactly once and the
+   caller observes the original error.
+2. **Given** a managed resource whose consuming task fails asynchronously (existing
+   behavior), **When** the failure occurs, **Then** the resource is still released exactly
+   once (no regression).
+3. **Given** a soak scenario where a fraction of operations fail immediately, **When** the
+   scenario runs to completion, **Then** the connection pool retains full capacity (no
+   leaked connections or statements).
+4. **Given** a managed resource whose consuming task fails AND whose release step also
+   fails with an ordinary (non-fatal) error, **When** the operation completes, **Then**
+   the caller observes the original task error with the release error attached as a
+   secondary (suppressed) failure, and release was attempted exactly once per resource.
+
+---
+
+### Edge Cases
+
+- Statement with zero parameters: preparation must still succeed with no binding work.
+- Statement with exactly one parameter: serialization requirement is trivially satisfied;
+  no overhead regression expected.
+- Single-threaded execution environment: behavior must be identical to today (the defects
+  only manifest on multi-threaded executors, the fix must not depend on thread count).
+- Stored-procedure call with only input or only output parameters: ordering guarantee
+  still holds within the single kind.
+- Query timeout of zero / not set: batches must not gain an implicit timeout.
+- Timeout expiring mid-batch: partial batch effects follow the database's timeout
+  semantics; the operation must be reported failed and its resources released.
+- Release step itself failing after a synchronous task failure: for ordinary (non-fatal)
+  release errors the original task error must be the one reported, with the release
+  failure attached secondarily (suppressed), and release must not be attempted twice.
+  Fatal JVM-level errors raised during release (e.g., out-of-memory, interruption) may
+  take precedence over the original error — platform resource-management semantics.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: For a single parameterized statement, the system MUST apply all parameter
+  bindings sequentially — at most one binding in progress at any instant — and MUST bind
+  every parameter position exactly once with its declared value, on any execution
+  environment. Relative order between distinct positions is not guaranteed and not
+  required. (#120)
+- **FR-002**: For a single stored-procedure call, the system MUST apply input parameter
+  bindings and output parameter registrations sequentially — no overlap — binding every
+  input position and registering every output position exactly once, on any execution
+  environment. (#121)
+- **FR-003**: Batch operations MUST honor the protocol-level query timeout exactly as
+  single-statement operations do: a batch exceeding the configured timeout MUST be aborted
+  and reported as failed. (#83)
+- **FR-004**: When no query timeout is configured, batch behavior MUST remain unchanged
+  (no implicit timeout).
+- **FR-005**: A managed database resource MUST be released exactly once on every
+  completion path of the task consuming it — success, asynchronous failure, and immediate
+  synchronous failure. (#100)
+- **FR-006**: When a consuming task fails synchronously, cleanup MUST still run, and the
+  caller MUST observe the original failure whenever any cleanup failure is an ordinary
+  (non-fatal) error — the cleanup failure is then attached as a secondary (suppressed)
+  error. Fatal JVM-level errors raised during cleanup may take precedence (platform
+  resource-management semantics).
+- **FR-007**: All fixes MUST preserve the published Scala DSL, Java/Kotlin facade
+  signatures, protocol defaults, and observable behavior for currently-working scenarios
+  (Constitution Principle I).
+- **FR-008**: Each fixed defect MUST be covered by a focused regression test exercising a
+  real database path (H2 or PostgreSQL) where one exists, including concurrency
+  instrumentation for FR-001/FR-002 and release-counting instrumentation (exactly-once
+  per resource, including a failing-release case) for FR-005/FR-006 (Constitution
+  Principle II; acceptance tests named in #83, #100, #120, #121).
+
+### Key Entities
+
+- **Statement operation**: One database action a virtual user performs (query, insert,
+  batch, raw SQL, stored-procedure call); owns an ordered set of parameter bindings and an
+  optional timeout.
+- **Parameter binding**: The association of one user-supplied value with one position of a
+  statement operation; the unit whose mutual overlap is being eliminated.
+- **Managed resource**: A pooled database artifact (connection, statement) acquired for
+  one operation and required to be released exactly once on all paths.
+- **Query timeout**: Protocol-level maximum duration for a statement operation; currently
+  enforced for single statements, extended by this feature to batches.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In an instrumented concurrency test, the maximum number of simultaneous
+  parameter-binding actions observed on one statement is exactly 1, across repeated runs
+  on a multi-threaded execution environment.
+- **SC-002**: A load scenario writing known distinct values via parameterized statements
+  and stored procedures reads back 100% correct values against a real database.
+- **SC-003**: A batch operation exceeding a configured N-second timeout is reported failed
+  in at most N seconds plus a small fixed margin, in 100% of runs; without a configured
+  timeout, batch runtime behavior is unchanged.
+- **SC-004**: After a soak scenario in which a fixed fraction of operations fail
+  immediately, the connection pool reports zero leaked connections and each managed
+  resource's release was invoked exactly once.
+- **SC-005**: The full existing test suite and the example simulation (`DebugTest`) pass
+  unchanged, demonstrating no regression for currently-working scenarios.
+- **SC-006**: All four milestone issues (#83, #100, #120, #121) are closed by changes
+  traceable to this specification, releasing milestone v1.2.0.
+
+## Assumptions
+
+- The audit baseline for all four defects is repository state
+  `a8d0401bd92ea694f5f550dd279e61d5581408c3`; evidence links in the issues refer to that
+  baseline and may have shifted line numbers on current `main`.
+- Batch rollback masking (#84) and non-batch autoCommit behavior (#88) are explicitly out
+  of scope — the milestone description tracks them as separate follow-ups.
+- The connection-pool deadlock itself (#57) is already fixed and merged (#59); this
+  feature covers only the remaining open concurrency defects in milestone v1.2.0.
+- Sequential (serialized) parameter binding introduces no meaningful throughput loss:
+  binding is cheap relative to statement execution, and correctness outranks marginal
+  parallelism inside a single statement.
+- No public API additions are required; all fixes are internal behavior corrections
+  covered by Constitution Principle I (backward compatibility preserved).
+- Binding order across distinct parameter positions is intentionally unspecified:
+  correctness is "each position bound exactly once with its declared value". (Adjusted
+  after adversarial review — the placeholder→index storage has no declaration-order
+  contract, and drivers do not require one; requiring it would force a production
+  rewrite with no user-visible benefit.)
+- Error-preservation on cleanup failure follows the platform's resource-management
+  severity semantics: ordinary cleanup errors never mask the original failure (they are
+  suppressed); fatal JVM-level errors may take precedence. (Adjusted after adversarial
+  review to match actual `scala.util.Using` behavior.)

--- a/specs/001-concurrency-hardening/tasks.md
+++ b/specs/001-concurrency-hardening/tasks.md
@@ -1,0 +1,184 @@
+# Tasks: Statement Concurrency & Resource-Safety Hardening
+
+**Input**: Design documents from `/specs/001-concurrency-hardening/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/jdbc-client-behavior.md, quickstart.md
+
+**Tests**: Tests ARE the deliverable of this feature (FR-008; issues #83/#100/#120/#121 each prescribe an acceptance test). Unlike classic TDD, these regression tests are expected to PASS against current `main` — they pin behavior already fixed by PR #59. A failing test means a residual defect (contingency path, only realistic for US3/#83).
+
+**Organization**: One user story = one GitHub issue = one semantic commit, green on its own (`sbt scalafmtCheckAll scalafmtSbtCheck compile test`) — Constitution IV.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: US1=#120, US2=#121, US3=#83, US4=#100
+
+## Path Conventions
+
+Single sbt project: `src/main/scala/...`, `src/test/scala/...` at repository root (per plan.md).
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Land spec artifacts first (Constitution IV), confirm green baseline.
+
+- [ ] T001 Commit spec artifacts: `git add specs/001-concurrency-hardening .specify/feature.json && git commit -m "docs(speckit): add 001-concurrency-hardening spec/plan/tasks"`. Do NOT include CLAUDE.md (AGENTS.md: never commit CLAUDE.md unless user explicitly asks).
+- [ ] T002 [P] Verify baseline green on branch `001-concurrency-hardening`: `sbt scalafmtCheckAll scalafmtSbtCheck compile test`
+- [ ] T003 [P] Verify Docker available for Testcontainers (`docker info`); if unavailable, note that PostgreSQL specs (US2/US3 parts) must run in CI
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Shared test instrumentation used by US1, US2, US4. No production code.
+
+**⚠️ CRITICAL**: US1/US2/U4 test tasks import these helpers; write them first. They are committed together with the first story commit that uses them (helpers alone don't map to an issue).
+
+- [ ] T004 Create concurrency-recording statement proxy in src/test/scala/org/galaxio/gatling/jdbc/db/testsupport/RecordingStatementProxy.scala — JDK `java.lang.reflect.Proxy` factory wrapping a real H2 `PreparedStatement`/`CallableStatement`; `InvocationHandler` tracks: current/max concurrent entries into `set*`/`setObject`/`registerOutParameter` (AtomicInteger enter/exit), per-index invocation counts, bound values per index; delegates every call to the real statement. Serves US1+US2 (contract G1.1/G1.3/G2.1).
+- [ ] T005 Create close-counting datasource in src/test/scala/org/galaxio/gatling/jdbc/db/testsupport/CloseCountingDataSource.scala — test-only `HikariDataSource` subclass; `getConnection` returns JDK-proxy `Connection` that (a) counts `close()` per connection, (b) wraps created `Statement`/`PreparedStatement`/`CallableStatement` in close-counting proxies, (c) supports injecting a non-fatal exception from one resource's `close()`. Serves US4 (contract G4.1/G4.2). No production seam — research.md decision.
+
+**Checkpoint**: helpers compile; user stories can start.
+
+---
+
+## Phase 3: User Story 1 — Correct parameter binding for parameterized queries under load (Priority: P1) 🎯 MVP — issue #120
+
+**Goal**: Prove PreparedStatement parameter binding is serialized (max concurrent == 1) and every position gets exactly its declared value exactly once; pin with regression tests (contract G1.*, FR-001).
+
+**Independent Test**: `sbt "testOnly org.galaxio.gatling.jdbc.db.StatementParamsConcurrencySpec"` green + H2/PG round-trip values 100% correct.
+
+### Tests for User Story 1
+
+- [ ] T006 [US1] Create src/test/scala/org/galaxio/gatling/jdbc/db/StatementParamsConcurrencySpec.scala (prepared-statement cases, using T004 proxy over real H2 connection): multi-param SQL (all `ParamVal` kinds incl. UUID, null, boolean, date) → assert max concurrent setter entry == 1; each JDBC index bound exactly once; bound values equal declared values; duplicate placeholder (`{a},{b},{a}`) binds every mapped index exactly once; zero-param and single-param edge cases prepare successfully; missing binding for a placeholder → operation fails with original exception, statement never executed (G1.4)
+- [ ] T007 [P] [US1] Extend src/test/scala/org/galaxio/gatling/jdbc/db/PostgreSQLIntegrationSpec.scala with concurrent value-correctness case: N≥50 concurrent `executeUpdate` inserts with distinct known multi-param rows through one `JDBCClient` → read back via `executeSelect`, assert 100% of rows contain exactly the declared values (SC-002)
+
+### Commit for User Story 1
+
+- [ ] T008 [US1] Format + gate + commit: `sbt scalafmtAll scalafmtSbt && sbt scalafmtCheckAll scalafmtSbtCheck compile test`, then `git add src/test && git commit -m "test(db): prove serialized PreparedStatement param binding (#120)"` (includes T004 helper; T005 if not yet committed stays unstaged)
+
+**Checkpoint**: US1 independently green; #120 acceptance satisfied.
+
+---
+
+## Phase 4: User Story 2 — Reliable stored-procedure IN/OUT registration under load (Priority: P2) — issue #121
+
+**Goal**: Prove CallableStatement IN binding + OUT registration are serialized, each position exactly once; correct OUT values from a real stored procedure under load (contract G2.*, FR-002).
+
+**Independent Test**: callable cases of `StatementParamsConcurrencySpec` + stored-proc case of `PostgreSQLIntegrationSpec` green.
+
+### Tests for User Story 2
+
+- [ ] T009 [US2] Add callable-statement cases to src/test/scala/org/galaxio/gatling/jdbc/db/StatementParamsConcurrencySpec.scala (T004 proxy over real H2 `CallableStatement` via `CREATE ALIAS`): mixed IN+OUT call → assert max concurrent setter/`registerOutParameter` entry == 1; every IN index bound exactly once; every OUT index registered exactly once; only-IN and only-OUT calls hold the same invariants; missing OUT placeholder → `IllegalArgumentException` naming missing params (G2.3, existing behavior)
+- [ ] T010 [P] [US2] Extend src/test/scala/org/galaxio/gatling/jdbc/db/PostgreSQLIntegrationSpec.scala with stored-procedure-under-load case: PostgreSQL function with IN + OUT params (`CREATE FUNCTION`), N≥50 concurrent `call` invocations with distinct inputs → every call returns correct OUT values for its inputs (SC-002)
+
+### Commit for User Story 2
+
+- [ ] T011 [US2] Format + gate + commit: `sbt scalafmtAll scalafmtSbt && sbt scalafmtCheckAll scalafmtSbtCheck compile test`, then `git commit -m "test(db): prove serialized CallableStatement IN/OUT registration (#121)"`
+
+**Checkpoint**: US1+US2 green independently.
+
+---
+
+## Phase 5: User Story 3 — Batch operations honor the configured query timeout (Priority: P3) — issue #83
+
+**Goal**: Prove a slow batch aborts as KO within configured timeout + margin; fast/no-timeout batches unchanged (contract G3.*, FR-003/FR-004). Only story with a realistic production-fix contingency.
+
+**Independent Test**: `sbt "testOnly org.galaxio.gatling.jdbc.db.BatchQueryTimeoutSpec"` green.
+
+### Tests for User Story 3
+
+- [ ] T012 [US3] Create src/test/scala/org/galaxio/gatling/jdbc/db/BatchQueryTimeoutSpec.scala (PostgreSQL Testcontainers, pattern from PostgreSQLIntegrationSpec:110-134): (a) `JDBCClient` with `queryTimeout = 1.second`, batch `INSERT ... SELECT ... , pg_sleep(10)` → `batch` completes as `Failure` (KO) within ~1s + fixed margin (assert wall-clock < 5s, not 10s), transaction rolled back, connection returned to pool; (b) same client, fast batch → succeeds with correct counts; (c) client with `queryTimeout = None`, moderately slow batch → completes without implicit timeout (G3.3)
+- [ ] T013 [US3] CONTINGENCY (only if T012(a) shows timeout not aborting): fix batch execution in src/main/scala/org/galaxio/gatling/jdbc/db/JDBCClient.scala `batch` method only, preserving G3.3/G3.4 and rollback semantics; re-run T012
+
+### Commit for User Story 3
+
+- [ ] T014 [US3] Format + gate + commit: `test(db): prove batch honors configured queryTimeout (#83)` — or `fix(db): enforce queryTimeout on batch statements (#83)` if T013 executed
+
+**Checkpoint**: US1-US3 green independently.
+
+---
+
+## Phase 6: User Story 4 — Resources always released when an operation fails immediately (Priority: P4) — issue #100
+
+**Goal**: Prove exactly-once release per resource on synchronous failure, original exception preserved (non-fatal cleanup failure suppressed), no leak under soak (contract G4.* as narrowed after adversarial review, FR-005/FR-006).
+
+**Independent Test**: `sbt "testOnly org.galaxio.gatling.jdbc.db.ResourceReleaseOnSyncThrowSpec"` green.
+
+### Tests for User Story 4
+
+- [ ] T015 [US4] Create src/test/scala/org/galaxio/gatling/jdbc/db/ResourceReleaseOnSyncThrowSpec.scala using T005 `CloseCountingDataSource` over H2: (a) sync-throw path — `executeSelect` with missing param binding (throws inside `Using` block before execution) → `Failure` carries original exception; every acquired resource's `close()` invoked exactly once; (b) combined-failure — operation fails AND one proxy resource's `close()` throws non-fatal exception → original exception is primary, close failure attached as suppressed (G4.2); (c) soak loop — ≥100 iterations of failing ops → per-iteration close counts stay exactly-once, `HikariPoolMXBean.getActiveConnections == 0` at end (SC-004); (d) success-path control — close counts exactly-once on success too (no regression)
+
+### Commit for User Story 4
+
+- [ ] T016 [US4] Format + gate + commit: `test(db): prove exactly-once resource release on synchronous failure (#100)` (includes T005 helper)
+
+**Checkpoint**: all four stories green independently.
+
+---
+
+## Phase 7: Polish & Delivery
+
+**Purpose**: Whole-suite verification, milestone-linked delivery.
+
+- [ ] T017 [P] Run example simulation regression guard: `sbt "Gatling / testOnly org.galaxio.performance.jdbc.test.DebugTest"` (SC-005)
+- [ ] T018 [P] Full gate + coverage: `sbt scalafmtCheckAll scalafmtSbtCheck compile test` and `sbt coverage test coverageReport coverageOff`
+- [ ] T019 Push branch and open PR to `main` titled `test(db): concurrency & resource-safety regression coverage for v1.2.0`, body with `Closes #83`, `Closes #100`, `Closes #120`, `Closes #121`, assigned to milestone `v1.2.0 — Connection-pool deadlock & concurrency hardening` (milestone 12); PR text states pool/timeout/thread analysis per Constitution III
+- [ ] T020 Validate linkage: `scripts/check-linkage.sh --pr <N>` passes (milestone + Closes + issues in same milestone)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: none — start immediately
+- **Foundational (Phase 2)**: after T001 (spec-first commit ordering); T004 blocks US1/US2 tests, T005 blocks US4 tests
+- **US1 (Phase 3)**: needs T004. **US2 (Phase 4)**: needs T004; T009 shares StatementParamsConcurrencySpec.scala with T006 → do T006 first (same file). **US3 (Phase 5)**: no helper deps — can run any time after Phase 1. **US4 (Phase 6)**: needs T005.
+- **Commit order**: T008 → T011 → T014 → T016 (each `1 issue = 1 commit`, sequential, each green). Stories' TEST AUTHORING can proceed in parallel; commits serialize.
+- **Polish (Phase 7)**: after all story commits.
+
+### User Story Dependencies
+
+- US1: independent (T004 helper only)
+- US2: file-level dependency on US1's T006 (same spec file); logically independent
+- US3: fully independent — earliest candidate for parallel work
+- US4: independent (T005 helper only)
+
+### Parallel Opportunities
+
+- T002 ∥ T003 (Phase 1)
+- T004 ∥ T005 (different files)
+- T007 ∥ T006 (different files); T010 ∥ T009 (different files)
+- US3 (T012) ∥ US1/US2/US4 test authoring — different files throughout
+- T017 ∥ T018
+
+---
+
+## Parallel Example: US1 + US3 together
+
+```bash
+# Different files, no shared state:
+Task A: "T006 prepared cases in StatementParamsConcurrencySpec.scala"
+Task B: "T012 BatchQueryTimeoutSpec.scala on PostgreSQL Testcontainers"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 = #120)
+
+1. Phase 1 (T001 spec commit, T002/T003 baseline)
+2. T004 helper → US1 tests (T006, T007) → T008 commit
+3. **STOP & VALIDATE**: `testOnly ...StatementParamsConcurrencySpec` + gate → #120 closable
+
+### Incremental Delivery
+
+Each subsequent story = one green commit closing one issue: US2 (#121) → US3 (#83) → US4 (#100). Any prefix of this sequence is shippable; milestone v1.2.0 becomes tag-ready only when all four land (check-linkage `--for-tag` gate).
+
+### Notes
+
+- Tests pin already-fixed behavior — expected green immediately; a red test = real finding (esp. T012a).
+- Instrumentation (proxies) lives in `testsupport/` only; zero production changes unless T013 contingency fires.
+- Scalafmt before every commit (pre-commit hook or `sbt scalafmtAll scalafmtSbt`).

--- a/specs/001-concurrency-hardening/tasks.md
+++ b/specs/001-concurrency-hardening/tasks.md
@@ -23,9 +23,9 @@ Single sbt project: `src/main/scala/...`, `src/test/scala/...` at repository roo
 
 **Purpose**: Land spec artifacts first (Constitution IV), confirm green baseline.
 
-- [ ] T001 Commit spec artifacts: `git add specs/001-concurrency-hardening .specify/feature.json && git commit -m "docs(speckit): add 001-concurrency-hardening spec/plan/tasks"`. Do NOT include CLAUDE.md (AGENTS.md: never commit CLAUDE.md unless user explicitly asks).
-- [ ] T002 [P] Verify baseline green on branch `001-concurrency-hardening`: `sbt scalafmtCheckAll scalafmtSbtCheck compile test`
-- [ ] T003 [P] Verify Docker available for Testcontainers (`docker info`); if unavailable, note that PostgreSQL specs (US2/US3 parts) must run in CI
+- [x] T001 Commit spec artifacts: `git add specs/001-concurrency-hardening .specify/feature.json && git commit -m "docs(speckit): add 001-concurrency-hardening spec/plan/tasks"`. Do NOT include CLAUDE.md (AGENTS.md: never commit CLAUDE.md unless user explicitly asks).
+- [x] T002 [P] Verify baseline green on branch `001-concurrency-hardening`: `sbt scalafmtCheckAll scalafmtSbtCheck compile test`
+- [x] T003 [P] Verify Docker available for Testcontainers (`docker info`); if unavailable, note that PostgreSQL specs (US2/US3 parts) must run in CI
 
 ---
 
@@ -35,8 +35,8 @@ Single sbt project: `src/main/scala/...`, `src/test/scala/...` at repository roo
 
 **⚠️ CRITICAL**: US1/US2/U4 test tasks import these helpers; write them first. They are committed together with the first story commit that uses them (helpers alone don't map to an issue).
 
-- [ ] T004 Create concurrency-recording statement proxy in src/test/scala/org/galaxio/gatling/jdbc/db/testsupport/RecordingStatementProxy.scala — JDK `java.lang.reflect.Proxy` factory wrapping a real H2 `PreparedStatement`/`CallableStatement`; `InvocationHandler` tracks: current/max concurrent entries into `set*`/`setObject`/`registerOutParameter` (AtomicInteger enter/exit), per-index invocation counts, bound values per index; delegates every call to the real statement. Serves US1+US2 (contract G1.1/G1.3/G2.1).
-- [ ] T005 Create close-counting datasource in src/test/scala/org/galaxio/gatling/jdbc/db/testsupport/CloseCountingDataSource.scala — test-only `HikariDataSource` subclass; `getConnection` returns JDK-proxy `Connection` that (a) counts `close()` per connection, (b) wraps created `Statement`/`PreparedStatement`/`CallableStatement` in close-counting proxies, (c) supports injecting a non-fatal exception from one resource's `close()`. Serves US4 (contract G4.1/G4.2). No production seam — research.md decision.
+- [x] T004 Create concurrency-recording statement proxy in src/test/scala/org/galaxio/gatling/jdbc/db/testsupport/RecordingStatementProxy.scala — JDK `java.lang.reflect.Proxy` factory wrapping a real H2 `PreparedStatement`/`CallableStatement`; `InvocationHandler` tracks: current/max concurrent entries into `set*`/`setObject`/`registerOutParameter` (AtomicInteger enter/exit), per-index invocation counts, bound values per index; delegates every call to the real statement. Serves US1+US2 (contract G1.1/G1.3/G2.1).
+- [x] T005 Create close-counting datasource in src/test/scala/org/galaxio/gatling/jdbc/db/testsupport/CloseCountingDataSource.scala — test-only `HikariDataSource` subclass; `getConnection` returns JDK-proxy `Connection` that (a) counts `close()` per connection, (b) wraps created `Statement`/`PreparedStatement`/`CallableStatement` in close-counting proxies, (c) supports injecting a non-fatal exception from one resource's `close()`. Serves US4 (contract G4.1/G4.2). No production seam — research.md decision.
 
 **Checkpoint**: helpers compile; user stories can start.
 
@@ -50,12 +50,12 @@ Single sbt project: `src/main/scala/...`, `src/test/scala/...` at repository roo
 
 ### Tests for User Story 1
 
-- [ ] T006 [US1] Create src/test/scala/org/galaxio/gatling/jdbc/db/StatementParamsConcurrencySpec.scala (prepared-statement cases, using T004 proxy over real H2 connection): multi-param SQL (all `ParamVal` kinds incl. UUID, null, boolean, date) → assert max concurrent setter entry == 1; each JDBC index bound exactly once; bound values equal declared values; duplicate placeholder (`{a},{b},{a}`) binds every mapped index exactly once; zero-param and single-param edge cases prepare successfully; missing binding for a placeholder → operation fails with original exception, statement never executed (G1.4)
-- [ ] T007 [P] [US1] Extend src/test/scala/org/galaxio/gatling/jdbc/db/PostgreSQLIntegrationSpec.scala with concurrent value-correctness case: N≥50 concurrent `executeUpdate` inserts with distinct known multi-param rows through one `JDBCClient` → read back via `executeSelect`, assert 100% of rows contain exactly the declared values (SC-002)
+- [x] T006 [US1] Create src/test/scala/org/galaxio/gatling/jdbc/db/StatementParamsConcurrencySpec.scala (prepared-statement cases, using T004 proxy over real H2 connection): multi-param SQL (all `ParamVal` kinds incl. UUID, null, boolean, date) → assert max concurrent setter entry == 1; each JDBC index bound exactly once; bound values equal declared values; duplicate placeholder (`{a},{b},{a}`) binds every mapped index exactly once; zero-param and single-param edge cases prepare successfully; missing binding for a placeholder → operation fails with original exception, statement never executed (G1.4)
+- [x] T007 [P] [US1] Extend src/test/scala/org/galaxio/gatling/jdbc/db/PostgreSQLIntegrationSpec.scala with concurrent value-correctness case: N≥50 concurrent `executeUpdate` inserts with distinct known multi-param rows through one `JDBCClient` → read back via `executeSelect`, assert 100% of rows contain exactly the declared values (SC-002)
 
 ### Commit for User Story 1
 
-- [ ] T008 [US1] Format + gate + commit: `sbt scalafmtAll scalafmtSbt && sbt scalafmtCheckAll scalafmtSbtCheck compile test`, then `git add src/test && git commit -m "test(db): prove serialized PreparedStatement param binding (#120)"` (includes T004 helper; T005 if not yet committed stays unstaged)
+- [x] T008 [US1] Format + gate + commit: `sbt scalafmtAll scalafmtSbt && sbt scalafmtCheckAll scalafmtSbtCheck compile test`, then `git add src/test && git commit -m "test(db): prove serialized PreparedStatement param binding (#120)"` (includes T004 helper; T005 if not yet committed stays unstaged)
 
 **Checkpoint**: US1 independently green; #120 acceptance satisfied.
 
@@ -69,12 +69,13 @@ Single sbt project: `src/main/scala/...`, `src/test/scala/...` at repository roo
 
 ### Tests for User Story 2
 
-- [ ] T009 [US2] Add callable-statement cases to src/test/scala/org/galaxio/gatling/jdbc/db/StatementParamsConcurrencySpec.scala (T004 proxy over real H2 `CallableStatement` via `CREATE ALIAS`): mixed IN+OUT call → assert max concurrent setter/`registerOutParameter` entry == 1; every IN index bound exactly once; every OUT index registered exactly once; only-IN and only-OUT calls hold the same invariants; missing OUT placeholder → `IllegalArgumentException` naming missing params (G2.3, existing behavior)
-- [ ] T010 [P] [US2] Extend src/test/scala/org/galaxio/gatling/jdbc/db/PostgreSQLIntegrationSpec.scala with stored-procedure-under-load case: PostgreSQL function with IN + OUT params (`CREATE FUNCTION`), N≥50 concurrent `call` invocations with distinct inputs → every call returns correct OUT values for its inputs (SC-002)
+- [x] T009 [US2] Add callable-statement cases to src/test/scala/org/galaxio/gatling/jdbc/db/StatementParamsConcurrencySpec.scala (T004 proxy over real H2 `CallableStatement` via `CREATE ALIAS`): mixed IN+OUT call → assert max concurrent setter/`registerOutParameter` entry == 1; every IN index bound exactly once; every OUT index registered exactly once; only-IN and only-OUT calls hold the same invariants; missing OUT placeholder → `IllegalArgumentException` naming missing params (G2.3, existing behavior)
+- [x] T010 [P] [US2] Extend src/test/scala/org/galaxio/gatling/jdbc/db/PostgreSQLIntegrationSpec.scala with stored-procedure-under-load case: PostgreSQL function with IN + OUT params (`CREATE FUNCTION`), N≥50 concurrent `call` invocations with distinct inputs → every call returns correct OUT values for its inputs (SC-002)
+  > **As built**: implemented on H2 (`CREATE ALIAS` + `? = CALL`, 50 concurrent `client.call`s in StatementParamsConcurrencySpec) instead of PostgreSQL. The pgjdbc OUT-parameter path requires the JDBC `{call ...}` escape syntax, but literal braces are consumed by the plugin's named-placeholder interpolator — a real product limitation worth its own issue; H2 provides the real-database OUT path without it.
 
 ### Commit for User Story 2
 
-- [ ] T011 [US2] Format + gate + commit: `sbt scalafmtAll scalafmtSbt && sbt scalafmtCheckAll scalafmtSbtCheck compile test`, then `git commit -m "test(db): prove serialized CallableStatement IN/OUT registration (#121)"`
+- [x] T011 [US2] Format + gate + commit: `sbt scalafmtAll scalafmtSbt && sbt scalafmtCheckAll scalafmtSbtCheck compile test`, then `git commit -m "test(db): prove serialized CallableStatement IN/OUT registration (#121)"`
 
 **Checkpoint**: US1+US2 green independently.
 
@@ -88,12 +89,13 @@ Single sbt project: `src/main/scala/...`, `src/test/scala/...` at repository roo
 
 ### Tests for User Story 3
 
-- [ ] T012 [US3] Create src/test/scala/org/galaxio/gatling/jdbc/db/BatchQueryTimeoutSpec.scala (PostgreSQL Testcontainers, pattern from PostgreSQLIntegrationSpec:110-134): (a) `JDBCClient` with `queryTimeout = 1.second`, batch `INSERT ... SELECT ... , pg_sleep(10)` → `batch` completes as `Failure` (KO) within ~1s + fixed margin (assert wall-clock < 5s, not 10s), transaction rolled back, connection returned to pool; (b) same client, fast batch → succeeds with correct counts; (c) client with `queryTimeout = None`, moderately slow batch → completes without implicit timeout (G3.3)
-- [ ] T013 [US3] CONTINGENCY (only if T012(a) shows timeout not aborting): fix batch execution in src/main/scala/org/galaxio/gatling/jdbc/db/JDBCClient.scala `batch` method only, preserving G3.3/G3.4 and rollback semantics; re-run T012
+- [x] T012 [US3] Create src/test/scala/org/galaxio/gatling/jdbc/db/BatchQueryTimeoutSpec.scala (PostgreSQL Testcontainers, pattern from PostgreSQLIntegrationSpec:110-134): (a) `JDBCClient` with `queryTimeout = 1.second`, batch `INSERT ... SELECT ... , pg_sleep(10)` → `batch` completes as `Failure` (KO) within ~1s + fixed margin (assert wall-clock < 5s, not 10s), transaction rolled back, connection returned to pool; (b) same client, fast batch → succeeds with correct counts; (c) client with `queryTimeout = None`, moderately slow batch → completes without implicit timeout (G3.3)
+- [x] T013 [US3] CONTINGENCY (only if T012(a) shows timeout not aborting): fix batch execution in src/main/scala/org/galaxio/gatling/jdbc/db/JDBCClient.scala `batch` method only, preserving G3.3/G3.4 and rollback semantics; re-run T012
+  > **Not needed**: T012(a) is green — the driver aborts the slow batch at the configured timeout (Failure in <5s vs a 10s sleep), rollback and pool release verified. No production change.
 
 ### Commit for User Story 3
 
-- [ ] T014 [US3] Format + gate + commit: `test(db): prove batch honors configured queryTimeout (#83)` — or `fix(db): enforce queryTimeout on batch statements (#83)` if T013 executed
+- [x] T014 [US3] Format + gate + commit: `test(db): prove batch honors configured queryTimeout (#83)` — or `fix(db): enforce queryTimeout on batch statements (#83)` if T013 executed
 
 **Checkpoint**: US1-US3 green independently.
 
@@ -107,11 +109,11 @@ Single sbt project: `src/main/scala/...`, `src/test/scala/...` at repository roo
 
 ### Tests for User Story 4
 
-- [ ] T015 [US4] Create src/test/scala/org/galaxio/gatling/jdbc/db/ResourceReleaseOnSyncThrowSpec.scala using T005 `CloseCountingDataSource` over H2: (a) sync-throw path — `executeSelect` with missing param binding (throws inside `Using` block before execution) → `Failure` carries original exception; every acquired resource's `close()` invoked exactly once; (b) combined-failure — operation fails AND one proxy resource's `close()` throws non-fatal exception → original exception is primary, close failure attached as suppressed (G4.2); (c) soak loop — ≥100 iterations of failing ops → per-iteration close counts stay exactly-once, `HikariPoolMXBean.getActiveConnections == 0` at end (SC-004); (d) success-path control — close counts exactly-once on success too (no regression)
+- [x] T015 [US4] Create src/test/scala/org/galaxio/gatling/jdbc/db/ResourceReleaseOnSyncThrowSpec.scala using T005 `CloseCountingDataSource` over H2: (a) sync-throw path — `executeSelect` with missing param binding (throws inside `Using` block before execution) → `Failure` carries original exception; every acquired resource's `close()` invoked exactly once; (b) combined-failure — operation fails AND one proxy resource's `close()` throws non-fatal exception → original exception is primary, close failure attached as suppressed (G4.2); (c) soak loop — ≥100 iterations of failing ops → per-iteration close counts stay exactly-once, `HikariPoolMXBean.getActiveConnections == 0` at end (SC-004); (d) success-path control — close counts exactly-once on success too (no regression)
 
 ### Commit for User Story 4
 
-- [ ] T016 [US4] Format + gate + commit: `test(db): prove exactly-once resource release on synchronous failure (#100)` (includes T005 helper)
+- [x] T016 [US4] Format + gate + commit: `test(db): prove exactly-once resource release on synchronous failure (#100)` (includes T005 helper)
 
 **Checkpoint**: all four stories green independently.
 
@@ -121,10 +123,10 @@ Single sbt project: `src/main/scala/...`, `src/test/scala/...` at repository roo
 
 **Purpose**: Whole-suite verification, milestone-linked delivery.
 
-- [ ] T017 [P] Run example simulation regression guard: `sbt "Gatling / testOnly org.galaxio.performance.jdbc.test.DebugTest"` (SC-005)
-- [ ] T018 [P] Full gate + coverage: `sbt scalafmtCheckAll scalafmtSbtCheck compile test` and `sbt coverage test coverageReport coverageOff`
-- [ ] T019 Push branch and open PR to `main` titled `test(db): concurrency & resource-safety regression coverage for v1.2.0`, body with `Closes #83`, `Closes #100`, `Closes #120`, `Closes #121`, assigned to milestone `v1.2.0 — Connection-pool deadlock & concurrency hardening` (milestone 12); PR text states pool/timeout/thread analysis per Constitution III
-- [ ] T020 Validate linkage: `scripts/check-linkage.sh --pr <N>` passes (milestone + Closes + issues in same milestone)
+- [x] T017 [P] Run example simulation regression guard: `sbt "Gatling / testOnly org.galaxio.performance.jdbc.test.DebugTest"` (SC-005)
+- [x] T018 [P] Full gate + coverage: `sbt scalafmtCheckAll scalafmtSbtCheck compile test` and `sbt coverage test coverageReport coverageOff`
+- [x] T019 Push branch and open PR to `main` titled `test(db): concurrency & resource-safety regression coverage for v1.2.0`, body with `Closes #83`, `Closes #100`, `Closes #120`, `Closes #121`, assigned to milestone `v1.2.0 — Connection-pool deadlock & concurrency hardening` (milestone 12); PR text states pool/timeout/thread analysis per Constitution III
+- [x] T020 Validate linkage: `scripts/check-linkage.sh --pr <N>` passes (milestone + Closes + issues in same milestone)
 
 ---
 

--- a/src/test/scala/org/galaxio/gatling/jdbc/db/BatchQueryTimeoutSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/db/BatchQueryTimeoutSpec.scala
@@ -1,0 +1,111 @@
+package org.galaxio.gatling.jdbc.db
+
+import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.TryValues.convertTryToSuccessOrFailure
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.testcontainers.containers.PostgreSQLContainer
+
+import java.sql.SQLException
+import java.util.concurrent.Executors
+import scala.concurrent.Await
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.util.Failure
+
+/** Acceptance tests for issue #83: batch statements must honor the protocol-level queryTimeout.
+  *
+  * The pre-#59 implementation prepared batch statements without applying queryTimeoutSeconds, so a slow batch could wait
+  * indefinitely. These tests prove on real PostgreSQL that a configured timeout aborts a slow batch as a Failure (KO) within
+  * the timeout plus a fixed margin, that fast batches under the same client are unaffected, and that batches without a
+  * configured timeout gain no implicit one.
+  */
+class BatchQueryTimeoutSpec extends AsyncFlatSpec with Matchers with BeforeAndAfterAll {
+
+  private val postgres: PostgreSQLContainer[_] = new PostgreSQLContainer("postgres:16-alpine")
+
+  /** Deadline for the aborted slow batch: 1s configured timeout + driver cancel margin — far below the 10s sleep. */
+  private val abortDeadlineMs = 5000L
+
+  override def beforeAll(): Unit = {
+    postgres.start()
+
+    val (_, client) = mkClient(None)
+    Await.result(
+      client.executeRaw(
+        "CREATE TABLE slow_batch (txt TEXT); CREATE TABLE fast_batch (id INT PRIMARY KEY, name VARCHAR(100))",
+      ) { result =>
+        result.success.value shouldBe false
+      },
+      30.seconds,
+    )
+    client.close()
+  }
+
+  override def afterAll(): Unit =
+    postgres.stop()
+
+  private def mkClient(timeout: Option[FiniteDuration]): (HikariDataSource, JDBCClient) = {
+    val cfg = new HikariConfig()
+    cfg.setJdbcUrl(postgres.getJdbcUrl)
+    cfg.setUsername(postgres.getUsername)
+    cfg.setPassword(postgres.getPassword)
+    cfg.setMaximumPoolSize(2)
+    val ds  = new HikariDataSource(cfg)
+    (ds, JDBCClient(ds, Executors.newFixedThreadPool(2), timeout))
+  }
+
+  "batch with configured queryTimeout" should "abort a slow batch as a Failure within the timeout plus a margin" in {
+    val (ds, client) = mkClient(Some(1.second))
+    val start        = System.currentTimeMillis()
+
+    client
+      .batch(Seq(SqlWithParam("INSERT INTO slow_batch (txt) SELECT 'x' FROM pg_sleep(10)", Seq.empty))) { result =>
+        val elapsed = System.currentTimeMillis() - start
+
+        result shouldBe a[Failure[_]]
+        result.failure.exception shouldBe a[SQLException]
+        elapsed should be < abortDeadlineMs
+      }
+      .flatMap { _ =>
+        // transaction rolled back and nothing committed
+        client.executeSelect("SELECT COUNT(*) AS cnt FROM slow_batch", Seq.empty) { result =>
+          result.success.value.head("cnt").asInstanceOf[Number].longValue() shouldBe 0L
+        }
+      }
+      .map { assertion =>
+        Thread.sleep(200)
+        ds.getHikariPoolMXBean.getActiveConnections shouldBe 0
+        assertion
+      }
+      .andThen(_ => client.close())
+  }
+
+  it should "leave fast batches unaffected under the same client" in {
+    val (_, client) = mkClient(Some(1.second))
+    val queries     = Seq(
+      SQL("INSERT INTO fast_batch (id, name) VALUES ({id},{name})").withParams("id" -> IntParam(1), "name" -> StrParam("a")),
+      SQL("INSERT INTO fast_batch (id, name) VALUES ({id},{name})").withParams("id" -> IntParam(2), "name" -> StrParam("b")),
+    )
+
+    client
+      .batch(queries) { result =>
+        result.success.value shouldBe Array(1, 1)
+      }
+      .andThen(_ => client.close())
+  }
+
+  "batch without queryTimeout" should "complete a slow batch without any implicit timeout" in {
+    val (_, client) = mkClient(None)
+    val start       = System.currentTimeMillis()
+
+    client
+      .batch(Seq(SqlWithParam("INSERT INTO slow_batch (txt) SELECT 'y' FROM pg_sleep(2)", Seq.empty))) { result =>
+        val elapsed = System.currentTimeMillis() - start
+
+        result.success.value shouldBe Array(1)
+        elapsed should be >= 2000L
+      }
+      .andThen(_ => client.close())
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/jdbc/db/PostgreSQLIntegrationSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/db/PostgreSQLIntegrationSpec.scala
@@ -172,4 +172,53 @@ class PostgreSQLIntegrationSpec extends AsyncFlatSpec with Matchers with BeforeA
         dataSource.getHikariPoolMXBean.getActiveConnections shouldBe 0
       }
   }
+
+  // Regression for issue #120: under concurrent load every multi-param insert must write
+  // exactly the values declared for it — no swapped or corrupted bindings between users.
+  it should "bind every parameter of concurrent multi-param inserts exactly to its declared value" in {
+    val n = 50
+
+    client
+      .executeRaw(
+        """CREATE TABLE IF NOT EXISTS conc_items (
+          |  id   INT PRIMARY KEY,
+          |  name VARCHAR(100),
+          |  flag BOOLEAN,
+          |  val  DOUBLE PRECISION
+          |)""".stripMargin,
+      ) { result =>
+        result.success.value shouldBe false
+      }
+      .flatMap { _ =>
+        Future.sequence {
+          (1 to n).map { i =>
+            client.executeUpdate(
+              "INSERT INTO conc_items (id, name, flag, val) VALUES ({id},{name},{flag},{val})",
+              Seq(
+                "id"   -> IntParam(i),
+                "name" -> StrParam(s"row-$i"),
+                "flag" -> BooleanParam(i % 2 == 0),
+                "val"  -> DoubleParam(i * 1.5),
+              ),
+            ) { result =>
+              result.success.value shouldBe 1
+            }
+          }
+        }
+      }
+      .flatMap { _ =>
+        client.executeSelect("SELECT id, name, flag, val FROM conc_items", Seq.empty) { result =>
+          val rows = result.success.value
+          rows should have size n.toLong
+
+          rows.foreach { row =>
+            val id = row("id").asInstanceOf[Number].intValue()
+            row("name") shouldBe s"row-$id"
+            row("flag") shouldBe (id % 2 == 0)
+            row("val") shouldBe id * 1.5
+          }
+          succeed
+        }
+      }
+  }
 }

--- a/src/test/scala/org/galaxio/gatling/jdbc/db/ResourceReleaseOnSyncThrowSpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/db/ResourceReleaseOnSyncThrowSpec.scala
@@ -1,0 +1,128 @@
+package org.galaxio.gatling.jdbc.db
+
+import com.zaxxer.hikari.HikariConfig
+import org.galaxio.gatling.jdbc.db.testsupport.CloseCountingDataSource
+import org.scalatest.TryValues._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.concurrent.Executors
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+import scala.util.{Failure, Try}
+
+/** Acceptance tests for issue #100: resources must be released exactly once when an operation fails synchronously.
+  *
+  * The pre-#59 ResourceFut installed its cleanup only after the use-function returned a Future, so a synchronous throw (e.g. a
+  * missing parameter binding) skipped release entirely. #59 replaced it with Using.Manager; these tests pin the exactly-once
+  * release per resource with close-counting proxies, the error-preservation semantics narrowed after adversarial review (a
+  * non-fatal release failure is suppressed under the original exception, never masking it), and leak-free behavior under a soak
+  * loop.
+  */
+class ResourceReleaseOnSyncThrowSpec extends AnyFlatSpec with Matchers {
+
+  /** SQL whose {b} placeholder is intentionally left unbound: setParams throws synchronously inside the Using block, before any
+    * statement execution.
+    */
+  private val unboundSql = "SELECT id FROM rel_items WHERE id = {a} AND name = {b}"
+
+  private def withCountingClient[T](f: (CloseCountingDataSource, JDBCClient) => T): T = {
+    val cfg = new HikariConfig()
+    cfg.setJdbcUrl("jdbc:h2:mem:release_test;DB_CLOSE_DELAY=-1")
+    cfg.setUsername("sa")
+    cfg.setPassword("")
+    cfg.setMaximumPoolSize(2)
+    val ds  = new CloseCountingDataSource(cfg)
+
+    val client = JDBCClient(ds, Executors.newFixedThreadPool(2))
+    try {
+      // DB_CLOSE_DELAY=-1 keeps the named in-memory DB alive across suite runs in one JVM —
+      // clear leftovers so repeated testOnly runs don't hit PK violations.
+      Await.result(
+        client.executeRaw(
+          "CREATE TABLE IF NOT EXISTS rel_items (id INT PRIMARY KEY, name VARCHAR(64)); DELETE FROM rel_items",
+        )(identity),
+        10.seconds,
+      )
+      ds.resetTracking()
+      f(ds, client)
+    } finally client.close()
+  }
+
+  private def failingSelect(client: JDBCClient): Try[List[Map[String, Any]]] =
+    Await.result(client.executeSelect(unboundSql, Seq("a" -> IntParam(1)))(identity), 10.seconds)
+
+  "a synchronously failing operation" should "surface the original exception and release every resource exactly once" in
+    withCountingClient { (ds, client) =>
+      val result = failingSelect(client)
+
+      result shouldBe a[Failure[_]]
+      result.failure.exception shouldBe a[NoSuchElementException]
+
+      ds.trackedResources should not be empty
+      ds.trackedResources.map(_.kind) should contain allOf ("connection", "statement")
+      all(ds.trackedResources.map(_.closeCount.get())) shouldBe 1
+
+      Thread.sleep(200)
+      ds.getHikariPoolMXBean.getActiveConnections shouldBe 0
+    }
+
+  it should "keep the original exception primary when release itself fails, attaching the close failure as suppressed" in
+    withCountingClient { (ds, client) =>
+      ds.failNextStatementClose = true
+
+      val result = failingSelect(client)
+
+      result shouldBe a[Failure[_]]
+      val exception = result.failure.exception
+      exception shouldBe a[NoSuchElementException]
+      exception.getSuppressed.map(_.getMessage) should contain("injected close failure")
+
+      all(ds.trackedResources.map(_.closeCount.get())) shouldBe 1
+
+      Thread.sleep(200)
+      ds.getHikariPoolMXBean.getActiveConnections shouldBe 0
+    }
+
+  it should "not leak any resource across a soak loop of failing operations" in
+    withCountingClient { (ds, client) =>
+      val iterations = 100
+
+      (1 to iterations).foreach { _ =>
+        failingSelect(client) shouldBe a[Failure[_]]
+      }
+
+      // one connection + one statement acquired (and released exactly once) per iteration
+      ds.trackedResources should have size (iterations * 2).toLong
+      all(ds.trackedResources.map(_.closeCount.get())) shouldBe 1
+
+      Thread.sleep(200)
+      ds.getHikariPoolMXBean.getActiveConnections shouldBe 0
+    }
+
+  "a successful operation" should "also release connection, statement and result set exactly once" in
+    withCountingClient { (ds, client) =>
+      Await
+        .result(
+          client.executeUpdate(
+            "INSERT INTO rel_items (id, name) VALUES ({id},{name})",
+            Seq("id" -> IntParam(1), "name" -> StrParam("ok")),
+          )(identity),
+          10.seconds,
+        )
+        .success
+        .value shouldBe 1
+
+      val selected = Await.result(
+        client.executeSelect("SELECT id, name FROM rel_items WHERE id = {id}", Seq("id" -> IntParam(1)))(identity),
+        10.seconds,
+      )
+      selected.success.value should have size 1
+
+      ds.trackedResources.map(_.kind).sorted shouldBe List("connection", "connection", "resultset", "statement", "statement")
+      all(ds.trackedResources.map(_.closeCount.get())) shouldBe 1
+
+      Thread.sleep(200)
+      ds.getHikariPoolMXBean.getActiveConnections shouldBe 0
+    }
+}

--- a/src/test/scala/org/galaxio/gatling/jdbc/db/StatementParamsConcurrencySpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/db/StatementParamsConcurrencySpec.scala
@@ -1,0 +1,199 @@
+package org.galaxio.gatling.jdbc.db
+
+import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
+import org.galaxio.gatling.jdbc.db.JDBCClient.Interpolator
+import org.galaxio.gatling.jdbc.db.statements._
+import org.galaxio.gatling.jdbc.db.testsupport.RecordingStatementProxy
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.TryValues._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+import scala.util.Failure
+
+/** Regression tests for issue #120: PreparedStatement parameter setters must never be launched concurrently.
+  *
+  * The pre-#59 implementation created one eager Future per setter, so two parameters of one statement could be bound
+  * concurrently on a multi-thread executor. These tests pin the fixed behavior with the instrumentation the issue prescribes: a
+  * recording proxy around a real H2 statement asserts that at most one indexed parameter call is in progress at any instant and
+  * that every index is bound exactly once with its declared value, while the H2 round-trip verifies the values the database
+  * actually received.
+  */
+class StatementParamsConcurrencySpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+
+  private var dataSource: HikariDataSource = _
+  private var client: JDBCClient           = _
+
+  override def beforeAll(): Unit = {
+    val cfg = new HikariConfig()
+    cfg.setJdbcUrl("jdbc:h2:mem:param_concurrency_test;DB_CLOSE_DELAY=-1")
+    cfg.setUsername("sa")
+    cfg.setPassword("")
+    cfg.setMaximumPoolSize(4)
+    dataSource = new HikariDataSource(cfg)
+
+    val conn = dataSource.getConnection
+    try {
+      conn
+        .createStatement()
+        .execute(
+          """CREATE TABLE IF NOT EXISTS param_items (
+            |  id   INT PRIMARY KEY,
+            |  name VARCHAR(255),
+            |  flag BOOLEAN,
+            |  val  DOUBLE,
+            |  uid  VARCHAR(64)
+            |)""".stripMargin,
+        )
+      conn
+        .createStatement()
+        .execute(
+          """CREATE TABLE IF NOT EXISTS dup_items (
+            |  id    INT PRIMARY KEY,
+            |  a_val INT,
+            |  b_val VARCHAR(255)
+            |)""".stripMargin,
+        )
+    } finally conn.close()
+
+    client = JDBCClient(dataSource, Executors.newFixedThreadPool(4))
+  }
+
+  override def afterAll(): Unit =
+    client.close()
+
+  private def clearTables(): Unit = {
+    val conn = dataSource.getConnection
+    try {
+      conn.createStatement().execute("DELETE FROM param_items")
+      conn.createStatement().execute("DELETE FROM dup_items")
+    } finally conn.close()
+  }
+
+  behavior of "PreparedStatement parameter binding (issue #120)"
+
+  it should "bind a multi-parameter statement with no overlapping setter calls, each index exactly once" in {
+    clearTables()
+    val sql  = "INSERT INTO param_items (id, name, flag, val, uid) VALUES ({id},{name},{flag},{val},{uid})"
+    val ctx  = Interpolator.interpolate(sql)
+    val conn = dataSource.getConnection
+    try {
+      val (stmt, recorder) = RecordingStatementProxy.prepared(conn.prepareStatement(ctx.queryString))
+      stmt.setParams(
+        ctx,
+        Map(
+          "id"   -> IntParam(1),
+          "name" -> StrParam("alice"),
+          "flag" -> BooleanParam(true),
+          "val"  -> DoubleParam(1.5),
+          "uid"  -> NullParam,
+        ),
+      )
+      stmt.executeUpdate() shouldBe 1
+
+      recorder.maxConcurrentParamCalls shouldBe 1
+      recorder.setterCountsByIndex shouldBe ctx.m.values.flatten.map(_ -> 1).toMap
+      recorder.registerCountsByIndex shouldBe empty
+      recorder.boundValueAt(ctx.m("id").head) shouldBe Integer.valueOf(1)
+      recorder.boundValueAt(ctx.m("name").head) shouldBe "alice"
+      recorder.boundValueAt(ctx.m("flag").head) shouldBe java.lang.Boolean.TRUE
+      recorder.boundValueAt(ctx.m("val").head) shouldBe java.lang.Double.valueOf(1.5)
+      recorder.boundValueAt(ctx.m("uid").head) shouldBe recorder.NullValue
+
+      val rs = conn.createStatement().executeQuery("SELECT name, flag, val, uid FROM param_items WHERE id = 1")
+      rs.next() shouldBe true
+      rs.getString(1) shouldBe "alice"
+      rs.getBoolean(2) shouldBe true
+      rs.getDouble(3) shouldBe 1.5
+      rs.getString(4) shouldBe null
+    } finally conn.close()
+  }
+
+  it should "bind every index of a duplicated placeholder exactly once" in {
+    clearTables()
+    val sql  = "INSERT INTO dup_items (id, a_val, b_val) VALUES ({a},{a},{b})"
+    val ctx  = Interpolator.interpolate(sql)
+    val conn = dataSource.getConnection
+    try {
+      val (stmt, recorder) = RecordingStatementProxy.prepared(conn.prepareStatement(ctx.queryString))
+      stmt.setParams(ctx, Map("a" -> IntParam(7), "b" -> StrParam("dup")))
+      stmt.executeUpdate() shouldBe 1
+
+      ctx.m("a") should have size 2
+      recorder.maxConcurrentParamCalls shouldBe 1
+      recorder.setterCountsByIndex shouldBe Map(1 -> 1, 2 -> 1, 3 -> 1)
+
+      val rs = conn.createStatement().executeQuery("SELECT a_val, b_val FROM dup_items WHERE id = 7")
+      rs.next() shouldBe true
+      rs.getInt(1) shouldBe 7
+      rs.getString(2) shouldBe "dup"
+    } finally conn.close()
+  }
+
+  it should "prepare a zero-parameter statement without any tracked setter calls" in {
+    clearTables()
+    val ctx  = Interpolator.interpolate("INSERT INTO param_items (id, name) VALUES (3, 'fixed')")
+    val conn = dataSource.getConnection
+    try {
+      val (stmt, recorder) = RecordingStatementProxy.prepared(conn.prepareStatement(ctx.queryString))
+      stmt.setParams(ctx, Map.empty)
+      stmt.executeUpdate() shouldBe 1
+
+      recorder.maxConcurrentParamCalls shouldBe 0
+      recorder.setterCountsByIndex shouldBe empty
+    } finally conn.close()
+  }
+
+  it should "fail the whole operation with the original exception when a placeholder has no binding" in {
+    clearTables()
+    val future = client.executeUpdate(
+      "INSERT INTO param_items (id, name) VALUES ({id},{name})",
+      Seq("id" -> IntParam(4)), // {name} intentionally unbound
+    )(identity)
+
+    val result = Await.result(future, 10.seconds)
+    result shouldBe a[Failure[_]]
+    result.failure.exception shouldBe a[NoSuchElementException]
+
+    val conn = dataSource.getConnection
+    try {
+      val rs = conn.createStatement().executeQuery("SELECT COUNT(*) FROM param_items WHERE id = 4")
+      rs.next() shouldBe true
+      rs.getInt(1) shouldBe 0 // statement was never executed
+    } finally conn.close()
+  }
+
+  it should "detect overlapping parameter calls (instrumentation sensitivity check)" in {
+    val ctx  = Interpolator.interpolate("SELECT id FROM param_items WHERE id = {a} AND val = {b}")
+    val conn = dataSource.getConnection
+    try {
+      val (stmt, recorder) = RecordingStatementProxy.prepared(conn.prepareStatement(ctx.queryString), holdMillis = 250)
+      val ready            = new CountDownLatch(2)
+      val done             = new CountDownLatch(2)
+      val pool             = Executors.newFixedThreadPool(2)
+
+      // Deliberately violate the contract: bind two parameters from two threads at once.
+      // The recorder must observe the overlap — this is what makes the maxConcurrent == 1
+      // assertions above meaningful.
+      pool.execute { () =>
+        ready.countDown(); ready.await(5, TimeUnit.SECONDS)
+        stmt.setInt(1, 1); done.countDown()
+      }
+      pool.execute { () =>
+        ready.countDown(); ready.await(5, TimeUnit.SECONDS)
+        stmt.setInt(2, 2); done.countDown()
+      }
+
+      done.await(5, TimeUnit.SECONDS) shouldBe true
+      pool.shutdown()
+
+      recorder.maxConcurrentParamCalls shouldBe 2
+    } finally conn.close()
+  }
+
+  // Client-level 50-user value-correctness for prepared statements lives in
+  // PostgreSQLIntegrationSpec ("bind every parameter of concurrent multi-param inserts...").
+}

--- a/src/test/scala/org/galaxio/gatling/jdbc/db/StatementParamsConcurrencySpec.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/db/StatementParamsConcurrencySpec.scala
@@ -9,9 +9,10 @@ import org.scalatest.TryValues._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.sql.Types
 import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
-import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.Failure
 
 /** Regression tests for issue #120: PreparedStatement parameter setters must never be launched concurrently.
@@ -23,6 +24,8 @@ import scala.util.Failure
   * actually received.
   */
 class StatementParamsConcurrencySpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
+
+  private implicit val ec: ExecutionContext = ExecutionContext.global
 
   private var dataSource: HikariDataSource = _
   private var client: JDBCClient           = _
@@ -56,6 +59,24 @@ class StatementParamsConcurrencySpec extends AnyFlatSpec with Matchers with Befo
             |  a_val INT,
             |  b_val VARCHAR(255)
             |)""".stripMargin,
+        )
+      conn
+        .createStatement()
+        .execute(
+          """CREATE ALIAS IF NOT EXISTS ECHO_FN AS $$
+            |String echoFn(String s, long n) {
+            |    return s + ":" + n;
+            |}
+            |$$""".stripMargin,
+        )
+      conn
+        .createStatement()
+        .execute(
+          """CREATE ALIAS IF NOT EXISTS FORTY_TWO AS $$
+            |long fortyTwo() {
+            |    return 42L;
+            |}
+            |$$""".stripMargin,
         )
     } finally conn.close()
 
@@ -196,4 +217,86 @@ class StatementParamsConcurrencySpec extends AnyFlatSpec with Matchers with Befo
 
   // Client-level 50-user value-correctness for prepared statements lives in
   // PostgreSQLIntegrationSpec ("bind every parameter of concurrent multi-param inserts...").
+
+  // ─── issue #121: CallableStatement IN binding and OUT registration ─────────────
+
+  behavior of "CallableStatement IN/OUT registration (issue #121)"
+
+  it should "bind IN params and register the OUT param with no overlap, each position exactly once" in {
+    val sql  = "{res} = CALL ECHO_FN({s},{n})"
+    val ctx  = Interpolator.interpolate(sql)
+    val conn = dataSource.getConnection
+    try {
+      val (stmt, recorder) = RecordingStatementProxy.callable(conn.prepareCall(ctx.queryString))
+      stmt.setParams(ctx, Map("s" -> StrParam("abc"), "n" -> LongParam(7L)), Map("res" -> Types.VARCHAR))
+      stmt.executeUpdate()
+
+      recorder.maxConcurrentParamCalls shouldBe 1
+      recorder.registerCountsByIndex shouldBe Map(ctx.m("res").head -> 1)
+      recorder.setterCountsByIndex shouldBe Map(ctx.m("s").head -> 1, ctx.m("n").head -> 1)
+      recorder.boundValueAt(ctx.m("s").head) shouldBe "abc"
+
+      stmt.getString(ctx.m("res").head) shouldBe "abc:7"
+    } finally conn.close()
+  }
+
+  it should "hold the same invariants for a call with only IN parameters" in {
+    val sql  = "CALL ECHO_FN({s},{n})"
+    val ctx  = Interpolator.interpolate(sql)
+    val conn = dataSource.getConnection
+    try {
+      val (stmt, recorder) = RecordingStatementProxy.callable(conn.prepareCall(ctx.queryString))
+      stmt.setParams(ctx, Map("s" -> StrParam("solo"), "n" -> LongParam(1L)), Map.empty)
+      stmt.execute()
+
+      recorder.maxConcurrentParamCalls shouldBe 1
+      recorder.registerCountsByIndex shouldBe empty
+      recorder.setterCountsByIndex shouldBe Map(ctx.m("s").head -> 1, ctx.m("n").head -> 1)
+    } finally conn.close()
+  }
+
+  it should "hold the same invariants for a call with only an OUT parameter" in {
+    val sql  = "{res} = CALL FORTY_TWO()"
+    val ctx  = Interpolator.interpolate(sql)
+    val conn = dataSource.getConnection
+    try {
+      val (stmt, recorder) = RecordingStatementProxy.callable(conn.prepareCall(ctx.queryString))
+      stmt.setParams(ctx, Map.empty, Map("res" -> Types.BIGINT))
+      stmt.executeUpdate()
+
+      recorder.maxConcurrentParamCalls shouldBe 1
+      recorder.setterCountsByIndex shouldBe empty
+      recorder.registerCountsByIndex shouldBe Map(ctx.m("res").head -> 1)
+
+      stmt.getLong(ctx.m("res").head) shouldBe 42L
+    } finally conn.close()
+  }
+
+  it should "fail with IllegalArgumentException naming the OUT parameter missing from the SQL placeholders" in {
+    val future = client.call(
+      "CALL ECHO_FN({s},{n})", // {res} placeholder intentionally absent
+      Seq("s"   -> StrParam("x"), "n" -> LongParam(2L)),
+      Seq("res" -> Types.VARCHAR),
+    )(identity)
+
+    val result = Await.result(future, 10.seconds)
+    result shouldBe a[Failure[_]]
+    result.failure.exception shouldBe an[IllegalArgumentException]
+    result.failure.exception.getMessage should include("res")
+  }
+
+  it should "return correct OUT values for every call under concurrent load" in {
+    val n       = 50
+    val futures = (1 to n).map { i =>
+      client.call(
+        "{res} = CALL ECHO_FN({s},{n})",
+        Seq("s"   -> StrParam(s"in-$i"), "n" -> LongParam(i.toLong)),
+        Seq("res" -> Types.VARCHAR),
+      ) { result =>
+        result.success.value shouldBe Map("res" -> s"in-$i:$i")
+      }
+    }
+    Await.result(Future.sequence(futures), 30.seconds)
+    succeed
+  }
 }

--- a/src/test/scala/org/galaxio/gatling/jdbc/db/testsupport/CloseCountingDataSource.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/db/testsupport/CloseCountingDataSource.scala
@@ -1,0 +1,76 @@
+package org.galaxio.gatling.jdbc.db.testsupport
+
+import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
+
+import java.lang.reflect.{InvocationHandler, InvocationTargetException, Method, Proxy}
+import java.sql.{CallableStatement, Connection, PreparedStatement, ResultSet, Statement}
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+import scala.jdk.CollectionConverters._
+
+/** One resource acquired through [[CloseCountingDataSource]] and the number of times it was closed. */
+final class TrackedResource(val kind: String) {
+  val closeCount = new AtomicInteger(0)
+}
+
+/** Test-only HikariDataSource that counts `close()` per acquired resource (issue #100, contract G4).
+  *
+  * Every connection handed out — and every statement/result set created through it — is wrapped in a JDK proxy that delegates
+  * all calls to the real pooled resource while recording each `close()`. This proves the exactly-once release invariant per
+  * resource, which pool-level metrics alone cannot (a zero active count says connections came back, not that each statement and
+  * result set was released exactly once).
+  *
+  * Setting `failNextStatementClose` makes the next statement `close()` throw AFTER delegating to the real close (the pool stays
+  * clean), which lets tests assert that a non-fatal release failure is suppressed under the original operation failure instead
+  * of masking it.
+  */
+final class CloseCountingDataSource(cfg: HikariConfig) extends HikariDataSource(cfg) {
+
+  private val tracked = new ConcurrentLinkedQueue[TrackedResource]()
+
+  /** Check-then-reset is not atomic: arm this only while a single operation is in flight. */
+  @volatile var failNextStatementClose: Boolean = false
+
+  def trackedResources: List[TrackedResource] = tracked.asScala.toList
+
+  def resetTracking(): Unit = {
+    tracked.clear()
+    failNextStatementClose = false
+  }
+
+  override def getConnection: Connection = wrap(super.getConnection, classOf[Connection], "connection")
+
+  private def wrap[T](delegate: AnyRef, iface: Class[T], kind: String): T = {
+    val record = new TrackedResource(kind)
+    tracked.add(record)
+
+    val handler = new InvocationHandler {
+      override def invoke(proxy: AnyRef, method: Method, args: Array[AnyRef]): AnyRef = method.getName match {
+        case "close"                                    =>
+          record.closeCount.incrementAndGet()
+          delegateCall(method, args)
+          if (kind == "statement" && failNextStatementClose) {
+            failNextStatementClose = false
+            throw new RuntimeException("injected close failure")
+          }
+          null
+        case "createStatement" if kind == "connection"  =>
+          wrap(delegateCall(method, args), classOf[Statement], "statement")
+        case "prepareStatement" if kind == "connection" =>
+          wrap(delegateCall(method, args), classOf[PreparedStatement], "statement")
+        case "prepareCall" if kind == "connection"      =>
+          wrap(delegateCall(method, args), classOf[CallableStatement], "statement")
+        case "executeQuery" if kind == "statement"      =>
+          wrap(delegateCall(method, args), classOf[ResultSet], "resultset")
+        case _                                          =>
+          delegateCall(method, args)
+      }
+
+      private def delegateCall(method: Method, args: Array[AnyRef]): AnyRef =
+        try method.invoke(delegate, args: _*)
+        catch { case e: InvocationTargetException => throw e.getCause }
+    }
+
+    Proxy.newProxyInstance(iface.getClassLoader, Array(iface), handler).asInstanceOf[T]
+  }
+}

--- a/src/test/scala/org/galaxio/gatling/jdbc/db/testsupport/RecordingStatementProxy.scala
+++ b/src/test/scala/org/galaxio/gatling/jdbc/db/testsupport/RecordingStatementProxy.scala
@@ -1,0 +1,90 @@
+package org.galaxio.gatling.jdbc.db.testsupport
+
+import java.lang.reflect.{InvocationHandler, InvocationTargetException, Method, Proxy}
+import java.sql.{CallableStatement, PreparedStatement}
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import scala.jdk.CollectionConverters._
+
+/** JDK-proxy instrumentation for the parameter-binding concurrency contract (issues #120/#121).
+  *
+  * Wraps a real statement and records, for every indexed parameter call (`setInt`, `setString`, ..., `registerOutParameter`):
+  *   - the maximum number of such calls in progress at the same instant (must stay 1 — no overlap),
+  *   - how many times each JDBC index was bound/registered (must be exactly once per index),
+  *   - the value bound at each index (must equal the declared value).
+  *
+  * Every call is delegated to the real statement, so the instrumented statement still executes against the real database.
+  * `holdMillis` keeps each tracked call inside the handler for a small window so that overlapping calls, if any, are reliably
+  * observed as `maxConcurrentParamCalls > 1`.
+  */
+final class RecordingStatementHandler(delegate: AnyRef, holdMillis: Long) extends InvocationHandler {
+
+  /** Marker stored instead of `null` bound values (ConcurrentHashMap cannot hold nulls). */
+  val NullValue: AnyRef = RecordingStatementProxy.NullValue
+
+  private val inFlight    = new AtomicInteger(0)
+  private val maxInFlight = new AtomicInteger(0)
+
+  private val setterCalls   = new ConcurrentHashMap[Integer, AtomicInteger]()
+  private val setterValues  = new ConcurrentHashMap[Integer, AnyRef]()
+  private val registerCalls = new ConcurrentHashMap[Integer, AtomicInteger]()
+
+  def maxConcurrentParamCalls: Int = maxInFlight.get()
+
+  def setterCountsByIndex: Map[Int, Int] =
+    setterCalls.asScala.map { case (k, v) => (k.intValue, v.get) }.toMap
+
+  def registerCountsByIndex: Map[Int, Int] =
+    registerCalls.asScala.map { case (k, v) => (k.intValue, v.get) }.toMap
+
+  def boundValueAt(index: Int): AnyRef = setterValues.get(Integer.valueOf(index))
+
+  private def isTrackedParamCall(method: Method): Boolean = {
+    val paramTypes = method.getParameterTypes
+    val indexed    = paramTypes.nonEmpty && paramTypes(0) == java.lang.Integer.TYPE
+    (method.getName.startsWith("set") && paramTypes.length >= 2 && indexed) ||
+    (method.getName == "registerOutParameter" && indexed)
+  }
+
+  override def invoke(proxy: AnyRef, method: Method, args: Array[AnyRef]): AnyRef =
+    if (isTrackedParamCall(method)) {
+      val current = inFlight.incrementAndGet()
+      maxInFlight.updateAndGet(m => math.max(m, current))
+      try {
+        if (holdMillis > 0) Thread.sleep(holdMillis)
+        val index = args(0).asInstanceOf[Integer]
+        if (method.getName == "registerOutParameter")
+          registerCalls.computeIfAbsent(index, _ => new AtomicInteger(0)).incrementAndGet()
+        else {
+          setterCalls.computeIfAbsent(index, _ => new AtomicInteger(0)).incrementAndGet()
+          setterValues.put(index, if (args.length > 1 && args(1) != null) args(1) else NullValue)
+        }
+        delegateCall(method, args)
+      } finally inFlight.decrementAndGet()
+    } else delegateCall(method, args)
+
+  private def delegateCall(method: Method, args: Array[AnyRef]): AnyRef =
+    try method.invoke(delegate, args: _*)
+    catch { case e: InvocationTargetException => throw e.getCause }
+}
+
+object RecordingStatementProxy {
+
+  case object NullValue
+
+  def prepared(delegate: PreparedStatement, holdMillis: Long = 1): (PreparedStatement, RecordingStatementHandler) = {
+    val handler = new RecordingStatementHandler(delegate, holdMillis)
+    val proxy   = Proxy
+      .newProxyInstance(classOf[PreparedStatement].getClassLoader, Array(classOf[PreparedStatement]), handler)
+      .asInstanceOf[PreparedStatement]
+    (proxy, handler)
+  }
+
+  def callable(delegate: CallableStatement, holdMillis: Long = 1): (CallableStatement, RecordingStatementHandler) = {
+    val handler = new RecordingStatementHandler(delegate, holdMillis)
+    val proxy   = Proxy
+      .newProxyInstance(classOf[CallableStatement].getClassLoader, Array(classOf[CallableStatement]), handler)
+      .asInstanceOf[CallableStatement]
+    (proxy, handler)
+  }
+}


### PR DESCRIPTION
Closes the four remaining open defects of milestone v1.2.0 with the acceptance/regression tests each issue prescribes. Phase-0 research established that PR #59 already removed every defect mechanism on `main`; this PR proves each guarantee on real databases and pins it against regression. Zero production changes.

Closes #83
Closes #100
Closes #120
Closes #121

## Per-issue coverage

| Issue | Test | Proves |
|-------|------|--------|
| #120 | `StatementParamsConcurrencySpec` (prepared cases) + PG concurrent insert case | max concurrent setter entry == 1, exactly-once binding per index (incl. duplicated placeholders, NULL, zero-param, unbound-placeholder failure), 100% value correctness for 50 concurrent users; sensitivity check proves the instrumentation detects overlap |
| #121 | `StatementParamsConcurrencySpec` (callable cases, H2 `CREATE ALIAS` + `? = CALL`) | no IN/OUT overlap, exactly-once bind/registration per position, correct OUT values for 50 concurrent calls, missing-OUT `IllegalArgumentException` path |
| #83 | `BatchQueryTimeoutSpec` (PostgreSQL Testcontainers) | 1s protocol queryTimeout aborts a `pg_sleep(10)` batch as KO in <5s, transaction rolled back, pool released; fast batches and no-timeout batches unchanged |
| #100 | `ResourceReleaseOnSyncThrowSpec` + `CloseCountingDataSource` | exactly-once `close()` per connection/statement/result set on synchronous failure, original exception primary with injected close failure suppressed, 100-iteration soak leak-free |

## Resource / concurrency / timeout analysis (Constitution III)

- **Pool**: Hikari `HikariPoolMXBean.getActiveConnections == 0` asserted after every failure path; soak loop proves no per-iteration leak. Per-resource exactly-once release proven by close-counting proxies (test-only `HikariDataSource` subclass — no production seam).
- **Timeouts**: `setQueryTimeout` verified to actually abort batch execution on PostgreSQL (driver cancel), not merely to be set; no implicit timeout introduced when unconfigured; sub-second round-up unchanged.
- **Threads**: all binding happens synchronously inside the operation's single blocking-pool Future (post-#59 invariant); recording proxies would report overlap if per-step futures were ever reintroduced.
- **Error propagation**: original exception stays primary; non-fatal release failures attach as suppressed per `scala.util.Using` severity ranking (contract narrowed after adversarial review, pinned by test).

## Notes

- Spec artifacts: `specs/001-concurrency-hardening/` (spec/plan/research/data-model/contract/quickstart/tasks).
- Found in passing, worth follow-up issues: pgjdbc `{call}` escape syntax is unusable through the named-placeholder interpolator (literal braces are consumed), so stored-proc OUT coverage runs on H2; UUID binding diverges between prepared (`setString`) and callable (`setObject`) paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)