### PR TITLE
fix(release): stop dropping non-Conventional-Commit messages from changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -26,7 +26,9 @@ trim = true
 
 [git]
 conventional_commits = true
-filter_unconventional = true
+# false: a commit that fails strict Conventional Commits parsing still reaches commit_parsers
+# (caught by the trailing catch-all below) instead of being silently dropped from the notes.
+filter_unconventional = false
 split_commits = false
 # First match wins. Deps before the maintenance catch-all; breaking first.
 commit_parsers = [
@@ -38,6 +40,9 @@ commit_parsers = [
   { message = "^docs", group = "<!-- 04 -->Documentation" },
   { message = "^chore\\(deps\\)", group = "<!-- 05 -->Dependencies" },
   { message = "^(refactor|test|ci|build|chore|style|revert)", group = "<!-- 06 -->Maintenance" },
+  # Catch-all: a non-Conventional-Commit message still ships (e.g. an older or squash-merged commit)
+  # instead of silently vanishing from the notes.
+  { message = ".*", group = "<!-- 07 -->Other" },
 ]
 filter_commits = false
 tag_pattern = "v[0-9].*"


### PR DESCRIPTION
Closes #144

## What

`filter_unconventional = true` silently skipped any commit whose message failed strict Conventional Commits parsing — before `commit_parsers` (and its groups) ever ran. `git-cliff -vv` showed the exact mechanism:

```
38b99bd - Commit did not match conventional format: `Missing type in the commit summary, expected `type: description`` (Fix Deadlock on Backpressure From Connection Pool (#59))
```

The published [v1.2.0 release notes](https://github.com/galax-io/gatling-jdbc-plugin/releases/tag/v1.2.0) ended up missing `38b99bd Fix Deadlock on Backpressure From Connection Pool (#59)` entirely — the actual fix issue #57 was filed for, and the reason milestone v1.2.0 exists.

## Fix

- `filter_unconventional = false` — a failed-parse commit still reaches `commit_parsers` instead of being dropped.
- Added a trailing catch-all `{ message = ".*", group = "<!-- 07 -->Other" }` so it lands in an "Other" group instead of vanishing.
- Kept `conventional_commits = true` (not `false`) — flipping that too would have re-added the `type(scope):` prefix to every already-conventional entry's description (verified and reverted; `filter_unconventional=false` alone is the minimal fix).

## Verification

```
$ git-cliff --config cliff.toml --tag v1.2.0 v1.1.0..v1.2.0
...
### Other
- Fix Deadlock on Backpressure From Connection Pool (#59) ([38b99bd](.../commit/38b99bd...))
```

Full history `v1.0.0..v1.2.0` regenerates cleanly, 24 entries, zero parse-error skips (`-vv` confirms).

## Follow-up (not in this PR)

The already-published v1.2.0 GitHub Release notes are still missing the #59 entry — will republish them with the corrected output once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)