### PR TITLE
fix: release gate cannot resolve patch-version milestones

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Enforced by [`scripts/check-linkage.sh`](scripts/check-linkage.sh) + the [`.clau
 - `scripts/check-linkage.sh --for-tag vX.Y.Z` — gate a release: every milestone issue closed, every PR merged.
 - `scripts/check-linkage.sh` — audit the active milestone (lowest-numbered open).
 
-> The `--for-tag` gate maps `vX.Y.Z` to the milestone whose **title starts with `vX.Y.0`**. Name release milestones `vX.Y.0 <description>` for the gate to resolve; audit and `--pr` modes work with any milestone name.
+> The `--for-tag` gate resolves `vX.Y.Z` to a milestone whose title starts with that **exact** version first (a dedicated patch milestone, e.g. `v1.3.1 <description>`); if none exists it falls back to the milestone whose title starts with `vX.Y.0`. Name release milestones `vX.Y.0 <description>` (or `vX.Y.Z <description>` for a dedicated patch milestone) for the gate to resolve; audit and `--pr` modes work with any milestone name.
 
 ## Commits & PRs
 
@@ -127,7 +127,7 @@ Pushing a `vX.Y.Z` tag on `main` or a `release/*` branch:
 
 ### Milestone gate
 
-A release milestone is **tag-ready** only when every issue in it is closed and every PR merged. Because a release is now a deliberate local `git tag vX.Y.Z` / tag push, the [`linkage-guard`](.claude/hooks/linkage-guard.sh) hook actually gates it: it runs `check-linkage.sh --for-tag vX.Y.Z` and blocks the tag until the milestone passes. Name release milestones `vX.Y.0 …` so the gate resolves (see Milestones). To enforce the same gate server-side, add a `scripts/check-linkage.sh --for-tag "$GITHUB_REF_NAME"` step to `release.yml` once milestones are version-named.
+A release milestone is **tag-ready** only when every issue in it is closed and every PR merged. Because a release is now a deliberate local `git tag vX.Y.Z` / tag push, the [`linkage-guard`](.claude/hooks/linkage-guard.sh) hook actually gates it: it runs `check-linkage.sh --for-tag vX.Y.Z` and blocks the tag until the milestone passes. Name release milestones `vX.Y.0 …`, or `vX.Y.Z …` for a dedicated patch milestone, so the gate resolves (see Milestones). To enforce the same gate server-side, add a `scripts/check-linkage.sh --for-tag "$GITHUB_REF_NAME"` step to `release.yml` once milestones are version-named.
 
 ### Rules
 

--- a/scripts/check-linkage.sh
+++ b/scripts/check-linkage.sh
@@ -83,12 +83,20 @@ if [ -n "$PR_NUM" ]; then
 fi
 
 # Map a release version (vX.Y.Z) to its milestone, then assert tag-readiness on it.
-# Patch versions map to the vX.Y.0 milestone (e.g. v1.23.1 -> "v1.23.0 …").
+# An exact vX.Y.Z-titled milestone wins if one exists (a dedicated patch milestone,
+# e.g. "v1.3.1 — …"); otherwise fall back to the vX.Y.0 minor milestone (e.g.
+# v1.23.1 -> "v1.23.0 …"). Both matches are digit-boundary safe so "v1.3.1" cannot
+# accidentally match a title starting "v1.3.10".
 if [ -n "$FOR_TAG" ]; then
-  v="${FOR_TAG#v}"; minor="v${v%.*}.0"
+  v="${FOR_TAG#v}"; minor="${v%.*}.0"
   MS=$(gh api "repos/$REPO/milestones?state=all&per_page=100" \
-        | jq -r --arg t "$minor" 'map(select(.title | startswith($t))) | .[0].number // empty')
-  [ -n "$MS" ] || { echo "error: no milestone whose title starts with '$minor' for tag $FOR_TAG" >&2; exit 2; }
+        | jq -r --arg exact "$v" --arg minor "$minor" '
+            def boundary_match($ver): "^v" + ($ver | gsub("\\."; "\\.")) + "(\\D|$)";
+            (map(select(.title | test(boundary_match($exact)))) | .[0].number) as $e |
+            (map(select(.title | test(boundary_match($minor)))) | .[0].number) as $m |
+            if $e != null then $e elif $m != null then $m else empty end
+          ')
+  [ -n "$MS" ] || { echo "error: no milestone titled 'v$v …' or 'v$minor …' for tag $FOR_TAG" >&2; exit 2; }
   TAG_MODE=1
 fi
 

--- a/scripts/current-milestone.sh
+++ b/scripts/current-milestone.sh
@@ -3,9 +3,11 @@
 # current-milestone.sh — print the CURRENT release milestone as "<number>\t<title>".
 # Prints nothing (exit 0) when no version milestone is open.
 #
-# "Current" = the single open milestone whose title starts with `vX.Y.0` (lowest
-# semver if several are open). Single source of truth for "which milestone is
-# current" — shared by scripts/check-linkage.sh and .claude/hooks/milestone-guard.sh.
+# "Current" = the single open milestone whose title starts with a semver `vX.Y.Z`
+# (lowest version if several are open — full major.minor.patch, so a patch
+# milestone like `v1.3.1` sorts correctly against `v1.3.0` and against `v1.4.0`).
+# Single source of truth for "which milestone is current" — shared by
+# scripts/check-linkage.sh and .claude/hooks/milestone-guard.sh.
 #
 # Env: REPO=owner/name overrides the repo (default: gh repo view of the checkout).
 # Exit: 0 ok (may print empty) | 2 cannot determine repo.
@@ -16,8 +18,9 @@ REPO="${REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null 
 
 gh api "repos/$REPO/milestones?state=open&per_page=100" --jq '
   [ .[]
-    | select(.title | test("^v[0-9]+\\.[0-9]+\\.0"))
-    | . + { _k: ((.title | capture("^v(?<a>[0-9]+)\\.(?<b>[0-9]+)")) | (.a|tonumber) * 100000 + (.b|tonumber)) }
+    | select(.title | test("^v[0-9]+\\.[0-9]+\\.[0-9]+"))
+    | . + { _k: ((.title | capture("^v(?<a>[0-9]+)\\.(?<b>[0-9]+)\\.(?<c>[0-9]+)"))
+                 | (.a|tonumber) * 100000000 + (.b|tonumber) * 100000 + (.c|tonumber)) }
   ]
   | sort_by(._k) | (.[0] // null)
   | if . == null then empty else "\(.number)\t\(.title)" end'


### PR DESCRIPTION
Closes #157.

Found during code review of #156 (Codex flagged it): `scripts/check-linkage.sh --for-tag` normalized every `vX.Y.Z` to the `vX.Y.0` milestone, and `scripts/current-milestone.sh` only recognized `vX.Y.0`-titled milestones. A dedicated patch milestone (e.g. `v1.3.1`, created for #156's four follow-up issues) was invisible to both — tagging `v1.3.1` would silently audit the unrelated, already-closed `v1.3.0` milestone and could report tag-ready while `v1.3.1`'s own issues/PR were still open.

## Fix

Both resolvers now try an exact `vX.Y.Z`-titled milestone first (digit-boundary safe: `v1.3.1` cannot accidentally match a title starting `v1.3.10`), falling back to `vX.Y.0` — so a real minor-release milestone still resolves exactly as before.

## Verification (live against this repo)

```
$ scripts/current-milestone.sh
13	v1.3.1

$ scripts/check-linkage.sh --for-tag v1.3.1
Milestone: #13  v1.3.1  (open)
✗ PR #156 is OPEN — must be MERGED before tagging
✗ issue #157/#155/#154/#153/#152 is open — must be closed before tagging
FAIL: 6 error(s), 0 warning(s).

$ scripts/check-linkage.sh --for-tag v1.3.0
Milestone: #6  v1.3.0 — Runtime correctness: check semantics & concurrency  (closed)
```

Before this fix, `--for-tag v1.3.1` resolved to milestone #6 (already fully merged/closed) and would have reported PASS — a false tag-ready signal. It now correctly resolves #13 and correctly reports FAIL. The `v1.3.0` case (minor-milestone fallback) is unchanged.

`AGENTS.md`'s two descriptions of the gate updated to match; `bash -n` and `shellcheck` both clean on both scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)