### PR TITLE
fix(docs): unresolvable javadoc link broke scaladoc generation

### DIFF
--- a/src/main/java/org/galaxio/gatling/javaapi/actions/BatchUpdateValuesStepAction.java
+++ b/src/main/java/org/galaxio/gatling/javaapi/actions/BatchUpdateValuesStepAction.java
@@ -14,7 +14,7 @@ public class BatchUpdateValuesStepAction {
     /**
      * Static, author-fixed WHERE clause. Gatling EL ({@code #{...}}) inside the clause is rejected at
      * construction time — it would resolve session data into statement text (issue #125); bind dynamic
-     * values with {@link #where(String, Map)} instead.
+     * values with {@code where(String, Map)} instead.
      */
     public BatchUpdateAction where(String whereExpression){
         return new BatchUpdateAction(wrapped.where(whereExpression));


### PR DESCRIPTION
## What

\`{@link #where(String, Map)}\` in \`BatchUpdateValuesStepAction.java\` (added by #125, merged in PR #161) fails scaladoc's cross-language javadoc-link resolver in this mixed Java+Scala build. Switched to \`{@code where(String, Map)}\` — plain text, not resolver-dependent, matching every other overload cross-reference already in the codebase.

## Why — urgent, blocks the v1.5.0 release

\`sbt compile\`/\`sbt test\` never exercise \`Compile/doc\`, so this was invisible through the entire 005-injection-secrets-null review/merge cycle. It surfaced only when the actual \`v1.5.0\` tag push ran \`sbt ci-release\`, which needs a docJar for Sonatype publishing:

\`\`\`
error: .../BatchUpdateValuesStepAction.java:14:5: Could not find any member to link for "#where(String,".
```
error] Scaladoc generation failed
```

The publish step failed in local docJar assembly, before any Sonatype network call — nothing was uploaded to the registry for \`v1.5.0\`. The existing tag/branch will be recreated on the fixed commit once this merges.

## Verification

- \`sbt doc\` — succeeds locally (repro confirmed, then fixed).
- \`sbt scalafmtCheckAll scalafmtSbtCheck compile test\` — 202 tests green.
- Grepped remaining \`{@link}\` usages in \`src/main/java\` — pre-existing ones already passed this same CI run (doc step got past them, only choked on the new line), so no other fix needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)